### PR TITLE
お問い合わせページから入会フォームを、ヘッダーとフッターからメンバーページへのアクセスを削除、twitterのurl変更

### DIFF
--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -87,7 +87,7 @@ export default function ContactPage() {
             <h1 className="text-3xl md:text-5xl font-bold mb-6">お問い合わせ</h1>
             <p className="text-xl">
               Lumosに関するご質問やお問い合わせはこちらのフォームからご連絡ください。<br></br>
-              ⼊会希望の⽅は⼊会フォームの⼊⼒をお願いします。
+              ⼊会希望の方もこちらのフォームからご連絡ください。
             </p>
           </div>
         </div>
@@ -104,7 +104,7 @@ export default function ContactPage() {
                 <Alert className="bg-green-50 border-green-200 text-green-800 mb-6">
                   <CheckCircle className="h-4 w-4 text-green-600" />
                   <AlertDescription>
-                    お問い合わせありがとうございます。内容を確認の上、担当者より折り返しご連絡いたします。
+                    お問い合わせありがとうございます。内容を確認の上、折り返しご連絡いたします。
                   </AlertDescription>
                 </Alert>
               ) : (
@@ -241,16 +241,17 @@ export default function ContactPage() {
       </section>
 
       {/* 入会手続き */}
+      {/*
       <section className="py-16 md:py-24 bg-gray-50">
         <div className="container mx-auto px-4 md:px-6">
           <div className="text-center mb-12">
             <h2 className="text-2xl font-bold mb-4">入会手続き</h2>
             <p className="text-gray-600">下記のURLからフォームの入力をお願いします。<br></br>※他大学も入会可</p>
           </div>
-              {/*ここに入会フォームのurlを貼る*/}
 
         </div>
       </section>
+      */}
     </>
   )
 }

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -26,11 +26,13 @@ export default function Footer() {
                   サークル紹介
                 </Link>
               </li>
+              {/*
               <li>
                 <Link href="/members" className="text-sm text-gray-300 hover:text-accent transition-colors">
                   メンバー
                 </Link>
               </li>
+              */}
               <li>
                 <Link href="/news" className="text-sm text-gray-300 hover:text-accent transition-colors">
                   お知らせ
@@ -47,11 +49,11 @@ export default function Footer() {
             <h3 className="text-lg font-bold mb-4">フォローする</h3>
             <div className="flex space-x-4">
               <Link
-                href="https://twitter.com/lumos_ynu"
+                href="https://x.com/lumos_program"
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-white hover:text-accent transition-colors"
-                aria-label="Twitter"
+                aria-label="X(Twitter)  "
               >
                 <Twitter className="h-6 w-6" />
               </Link>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -9,7 +9,7 @@ import { cn } from "@/lib/utils"
 const navigation = [
   { name: "ホーム", href: "/" },
   { name: "サークル紹介", href: "/about" },
-  { name: "メンバー", href: "/members" },
+  //  { name: "メンバー", href: "/members" },
   { name: "お知らせ", href: "/news" },
   { name: "お問い合わせ", href: "/contact" },
 ]


### PR DESCRIPTION
お問い合わせページから入会フォームの削除、ヘッダーとフッターからメンバーページへの移動ボタンを削除、twitterのurl変更を行いました。あくまでページにアクセスできなくしただけであり、urlを直接打ち込めばメンバーページにアクセス可能です。