### PR TITLE
🐛 OAuthコールバックのリダイレクト先がCloud Run内部アドレスになる問題を修正

### DIFF
--- a/app/api/auth/link/github/callback/route.ts
+++ b/app/api/auth/link/github/callback/route.ts
@@ -17,25 +17,26 @@ export async function GET(request: NextRequest) {
   cookieStore.delete('oauth_link_discord_id')
   cookieStore.delete('oauth_link_redirect')
 
+  const origin = process.env.AUTH_URL ?? request.nextUrl.origin
+
   if (!code || !state || state !== savedState || !discordId) {
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'github_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }
 
   try {
-    const baseUrl = process.env.AUTH_URL ?? request.nextUrl.origin
-    const token = await exchangeCodeForToken('github', code, getCallbackUrl('github', baseUrl))
+    const token = await exchangeCodeForToken('github', code, getCallbackUrl('github', origin))
     const user = await fetchProviderUser('github', token)
 
     await updateMemberSns(discordId, { github: user.username, githubId: user.id, githubAvatar: user.avatar })
 
-    const successUrl = new URL(redirectTo, request.nextUrl.origin)
+    const successUrl = new URL(redirectTo, origin)
     successUrl.searchParams.set('success', 'github_linked')
     return NextResponse.redirect(successUrl.toString())
   } catch (e) {
     console.error('GitHub link callback error:', e)
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'github_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }

--- a/app/api/auth/link/line/callback/route.ts
+++ b/app/api/auth/link/line/callback/route.ts
@@ -17,13 +17,14 @@ export async function GET(request: NextRequest) {
   cookieStore.delete('oauth_link_discord_id')
   cookieStore.delete('oauth_link_redirect')
 
+  const origin = process.env.AUTH_URL ?? request.nextUrl.origin
+
   if (!code || !state || state !== savedState || !discordId) {
-    return NextResponse.redirect(new URL('/internal/settings?error=line_link_failed', request.nextUrl.origin))
+    return NextResponse.redirect(new URL('/internal/settings?error=line_link_failed', origin))
   }
 
   try {
-    const baseUrl = process.env.AUTH_URL ?? request.nextUrl.origin
-    const tokenResponse = await exchangeCodeForTokenFull('line', code, getCallbackUrl('line', baseUrl))
+    const tokenResponse = await exchangeCodeForTokenFull('line', code, getCallbackUrl('line', origin))
     const user = await fetchProviderUser('line', tokenResponse.access_token)
 
     await updateMemberSns(discordId, {
@@ -37,12 +38,12 @@ export async function GET(request: NextRequest) {
         : undefined,
     })
 
-    const successUrl = new URL(redirectTo, request.nextUrl.origin)
+    const successUrl = new URL(redirectTo, origin)
     successUrl.searchParams.set('success', 'line_linked')
     return NextResponse.redirect(successUrl.toString())
   } catch (e) {
     console.error('LINE link callback error:', e)
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'line_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }

--- a/app/api/auth/link/linkedin/callback/route.ts
+++ b/app/api/auth/link/linkedin/callback/route.ts
@@ -17,15 +17,16 @@ export async function GET(request: NextRequest) {
   cookieStore.delete('oauth_link_discord_id')
   cookieStore.delete('oauth_link_redirect')
 
+  const origin = process.env.AUTH_URL ?? request.nextUrl.origin
+
   if (!code || !state || state !== savedState || !discordId) {
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'linkedin_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }
 
   try {
-    const baseUrl = process.env.AUTH_URL ?? request.nextUrl.origin
-    const token = await exchangeCodeForToken('linkedin', code, getCallbackUrl('linkedin', baseUrl))
+    const token = await exchangeCodeForToken('linkedin', code, getCallbackUrl('linkedin', origin))
     const user = await fetchProviderUser('linkedin', token)
 
     await updateMemberSns(discordId, {
@@ -38,12 +39,12 @@ export async function GET(request: NextRequest) {
       ...(user.lastName ? { linkedinLastName: user.lastName } : {}),
     })
 
-    const successUrl = new URL(redirectTo, request.nextUrl.origin)
+    const successUrl = new URL(redirectTo, origin)
     successUrl.searchParams.set('success', 'linkedin_linked')
     return NextResponse.redirect(successUrl.toString())
   } catch (e) {
     console.error('LinkedIn link callback error:', e)
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'linkedin_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }

--- a/app/api/auth/link/x/callback/route.ts
+++ b/app/api/auth/link/x/callback/route.ts
@@ -19,25 +19,26 @@ export async function GET(request: NextRequest) {
   cookieStore.delete('oauth_link_discord_id')
   cookieStore.delete('oauth_link_redirect')
 
+  const origin = process.env.AUTH_URL ?? request.nextUrl.origin
+
   if (!code || !state || state !== savedState || !discordId || !codeVerifier) {
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'x_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }
 
   try {
-    const baseUrl = process.env.AUTH_URL ?? request.nextUrl.origin
-    const token = await exchangeCodeForToken('x', code, getCallbackUrl('x', baseUrl), codeVerifier)
+    const token = await exchangeCodeForToken('x', code, getCallbackUrl('x', origin), codeVerifier)
     const user = await fetchProviderUser('x', token)
 
     await updateMemberSns(discordId, { x: user.username, xId: user.id, xAvatar: user.avatar })
 
-    const successUrl = new URL(redirectTo, request.nextUrl.origin)
+    const successUrl = new URL(redirectTo, origin)
     successUrl.searchParams.set('success', 'x_linked')
     return NextResponse.redirect(successUrl.toString())
   } catch (e) {
     console.error('X link callback error:', e)
-    const errorUrl = new URL(redirectTo, request.nextUrl.origin)
+    const errorUrl = new URL(redirectTo, origin)
     errorUrl.searchParams.set('error', 'x_link_failed')
     return NextResponse.redirect(errorUrl.toString())
   }


### PR DESCRIPTION
## Summary
- OAuth連携（LINE/GitHub/X/LinkedIn）のコールバック後のリダイレクトで `request.nextUrl.origin` を使用していたため、Cloud Run環境では `https://0.0.0.0:8080` にリダイレクトされる問題を修正
- 全4プロバイダのcallback routeで `process.env.AUTH_URL` を使用するよう統一（未設定時は `request.nextUrl.origin` にフォールバック）
- トークン交換用URLとリダイレクト用URLで同じ `origin` 変数を使い、重複した `baseUrl` 変数を削除

## 修正ファイル
- `app/api/auth/link/line/callback/route.ts`
- `app/api/auth/link/github/callback/route.ts`
- `app/api/auth/link/x/callback/route.ts`
- `app/api/auth/link/linkedin/callback/route.ts`

## 原因
Cloud Runではコンテナが `0.0.0.0:8080` でリッスンしており、`request.nextUrl.origin` がその内部アドレスを返す。認証開始側のrouteでは既に `AUTH_URL` を使用していたが、callback側では `request.nextUrl.origin` が残っていた。

## Test plan
- [ ] LINE連携後に正しいURLにリダイレクトされることを確認
- [ ] 他プロバイダ（GitHub/X/LinkedIn）も同様に確認
- [ ] エラー時のリダイレクトも正しいURLになることを確認