### PR TITLE
🐛 卒業生オンボーディングStep2: 学部選択時のバグ修正 & 卒業年度フィールド追加

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -84,6 +84,9 @@ export async function PUT(request: Request) {
         if (typeof entry.transferYear === "string" && entry.transferYear) {
           record.transferYear = entry.transferYear
         }
+        if (typeof entry.graduationYear === "string" && entry.graduationYear) {
+          record.graduationYear = entry.graduationYear
+        }
         return record
       })
     }

--- a/app/internal/(protected)/profile/page.tsx
+++ b/app/internal/(protected)/profile/page.tsx
@@ -148,6 +148,15 @@ export default async function ProfilePage() {
                   <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium">役職</p>
                   <p className="text-sm font-medium mt-0.5">{member.role || "未設定"}</p>
                 </div>
+                {member.memberType === "卒業生" && (() => {
+                  const gradYear = member.enrollments?.find(e => e.isCurrent)?.graduationYear
+                  return gradYear ? (
+                    <div>
+                      <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium">卒業年度</p>
+                      <p className="text-sm font-medium mt-0.5">{gradYear}年度</p>
+                    </div>
+                  ) : null
+                })()}
                 {member.memberType === "卒業生" && (
                   <div>
                     <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium">現在の所属</p>

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -5,6 +5,7 @@ import {useRouter, useSearchParams} from "next/navigation"
 import {toast} from "@/hooks/use-toast"
 import {cropAndResizeImage} from "@/lib/image-crop"
 import type {EnrollmentType} from "@/types/profile"
+import {GRADUATE_SCHOOLS} from "@/types/profile"
 import {DEFAULT_RING_COLOR} from "@/types/member"
 import type {RingColorKey} from "@/types/member"
 import type {SnsEntry} from "@/components/member-tile-preview"
@@ -117,7 +118,8 @@ export default function OnboardingForm() {
             faculty: string;
             admissionYear: string;
             enrollmentType: string;
-            transferYear?: string
+            transferYear?: string;
+            graduationYear?: string
           }
           const enrollments: EnrollmentEntry[] = data.enrollments ?? []
           const currentEnrollment = enrollments.find((e) => e.isCurrent)
@@ -151,6 +153,7 @@ export default function OnboardingForm() {
             admissionYear: currentEnrollment?.admissionYear || cache.admissionYear || "",
             enrollmentType: ((currentEnrollment?.enrollmentType || cache.enrollmentType || "") as EnrollmentType | ""),
             transferYear: currentEnrollment?.transferYear || cache.transferYear || "",
+            graduationYear: currentEnrollment?.graduationYear || cache.graduationYear || "",
             hasUndergrad: hasUndergrad ?? cache.hasUndergrad ?? null,
             undergradFaculty: undergradEnrollment?.faculty || cache.undergradFaculty || "",
             undergradAdmissionYear: undergradEnrollment?.admissionYear || cache.undergradAdmissionYear || "",
@@ -353,6 +356,7 @@ export default function OnboardingForm() {
         admissionYear: data.admissionYear,
         enrollmentType: data.enrollmentType || "入学",
         ...(data.transferYear ? {transferYear: data.transferYear} : {}),
+        ...(data.graduationYear ? {graduationYear: data.graduationYear} : {}),
         isCurrent: true,
       }] : []),
       ...((data.memberType === "院生" || data.memberType === "卒業生") && data.hasUndergrad && data.undergradFaculty ? [{
@@ -402,8 +406,11 @@ export default function OnboardingForm() {
     if (form.memberType && form.memberType !== "卒業生" && !form.schoolYear) errors.schoolYear = "学年を選択してください"
     if (!form.faculty) errors.faculty = "学部/学府を選択してください"
     if (!form.admissionYear) errors.admissionYear = "入学年度を選択してください"
-    // 院生・卒業生で hasUndergrad=true の場合
-    if ((form.memberType === "院生" || form.memberType === "卒業生") && form.hasUndergrad === true) {
+    if (form.memberType === "卒業生" && !form.graduationYear) errors.graduationYear = "卒業年度を選択してください"
+    // 院生、または卒業生かつ学府選択時で hasUndergrad=true の場合
+    const showUndergradSection = form.memberType === "院生" ||
+      (form.memberType === "卒業生" && (GRADUATE_SCHOOLS as readonly string[]).includes(form.faculty))
+    if (showUndergradSection && form.hasUndergrad === true) {
       if (!form.undergradFaculty) errors.undergradFaculty = "所属学部を選択してください"
       if (!form.undergradAdmissionYear) errors.undergradAdmissionYear = "入学年度を選択してください"
     }

--- a/components/onboarding/step2-enrollment.tsx
+++ b/components/onboarding/step2-enrollment.tsx
@@ -4,7 +4,7 @@ import type {Dispatch, SetStateAction} from "react"
 import {Button} from "@/components/ui/button"
 import {Input} from "@/components/ui/input"
 import {Label} from "@/components/ui/label"
-import {MEMBER_TYPES, ENROLLMENT_TYPES, ADMISSION_YEARS, FACULTIES, getFacultyOptions} from "@/types/profile"
+import {MEMBER_TYPES, ENROLLMENT_TYPES, ADMISSION_YEARS, FACULTIES, GRADUATE_SCHOOLS, getFacultyOptions} from "@/types/profile"
 import type {FormData} from "./types"
 import {getSchoolYearOptions} from "./types"
 
@@ -43,6 +43,7 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
                     memberType: type,
                     schoolYear: "",
                     faculty: "",
+                    graduationYear: "",
                     currentOrg: ""
                   }))
                   setStep2Errors((p) => ({...p, memberType: undefined, faculty: undefined}))
@@ -103,7 +104,19 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
                 id="faculty"
                 value={form.faculty}
                 onChange={(e) => {
-                  setFormStep2((f) => ({...f, faculty: e.target.value}))
+                  const val = e.target.value
+                  setFormStep2((f) => {
+                    const updated = {...f, faculty: val}
+                    // 卒業生が学部を選んだ場合、学部在籍情報をリセット
+                    if (f.memberType === "卒業生" && !(GRADUATE_SCHOOLS as readonly string[]).includes(val)) {
+                      updated.hasUndergrad = null
+                      updated.undergradFaculty = ""
+                      updated.undergradAdmissionYear = ""
+                      updated.undergradEnrollmentType = ""
+                      updated.undergradTransferYear = ""
+                    }
+                    return updated
+                  })
                   if (step2Errors.faculty) setStep2Errors((p) => ({...p, faculty: undefined}))
                 }}
                 className={[
@@ -191,6 +204,30 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
                 </button>
               ))}
             </div>
+          </div>
+        )}
+
+        {/* 卒業生のみ：卒業年度 */}
+        {form.memberType === "卒業生" && (
+          <div className="space-y-1.5 animate-[fadeInUp_300ms_ease_both]">
+            <Label>卒業年度 <span className="text-red-500">*</span></Label>
+            <select
+              value={form.graduationYear}
+              onChange={(e) => {
+                setFormStep2((f) => ({...f, graduationYear: e.target.value}))
+                if (step2Errors.graduationYear) setStep2Errors((p) => ({...p, graduationYear: undefined}))
+              }}
+              className={[
+                "block w-full border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100",
+                step2Errors.graduationYear ? "border-red-400" : "border-input dark:border-gray-700",
+              ].join(" ")}
+            >
+              <option value="">年度を選択</option>
+              {ADMISSION_YEARS.map((y) => (
+                <option key={y} value={y}>{y}年度</option>
+              ))}
+            </select>
+            {step2Errors.graduationYear && <p className="text-xs text-red-500">{step2Errors.graduationYear}</p>}
           </div>
         )}
 
@@ -331,8 +368,8 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
           </div>
         )}
 
-        {/* 卒業生のみ：学部在籍確認 + 学部時代の情報 */}
-        {form.memberType === "卒業生" && (
+        {/* 卒業生かつ学府卒の場合のみ：学部在籍確認 + 学部時代の情報 */}
+        {form.memberType === "卒業生" && (GRADUATE_SCHOOLS as readonly string[]).includes(form.faculty) && (
           <div
             className="space-y-4 animate-[fadeInUp_300ms_ease_both] border-t border-gray-100 dark:border-gray-800 pt-4 mt-2">
             <div className="space-y-1.5">

--- a/components/onboarding/types.tsx
+++ b/components/onboarding/types.tsx
@@ -18,6 +18,7 @@ export interface FormData {
   enrollmentType: EnrollmentType | ""
   transferYear: string
   // 院生のみ：学部時代の情報
+  graduationYear: string    // 卒業年度（卒業生のみ）
   hasUndergrad: boolean | null   // null=未選択
   undergradFaculty: string
   undergradAdmissionYear: string
@@ -62,6 +63,7 @@ export const DEFAULT_FORM: FormData = {
   admissionYear: "",
   enrollmentType: "",
   transferYear: "",
+  graduationYear: "",
   hasUndergrad: null,
   undergradFaculty: "",
   undergradAdmissionYear: "",

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -22,6 +22,7 @@ export interface EnrollmentRecord {
   admissionYear: string
   enrollmentType: EnrollmentType
   transferYear?: string   // 編入時のみ
+  graduationYear?: string // 卒業年度（卒業生のみ）
   isCurrent: boolean
 }
 


### PR DESCRIPTION
## Summary
- 卒業生が学部を選んだ場合に「学部に在籍しましたか？」が不要に表示される問題を修正（学府選択時のみ表示するよう変更）
- 非表示フィールドのバリデーションエラーにより「次へ」ボタンで進めないバグを修正
- 卒業生向けに卒業年度フィールドを新規追加（必須項目）
- プロフィール表示ページに卒業年度を表示

## 原因
卒業生セクションの「学部に在籍しましたか？」は `memberType === "卒業生"` のみで表示制御されていたが、学部卒業の場合はこの質問自体が不要。また、以前のセッションで `hasUndergrad=true` が保存されていた場合、UIでは非表示だがバリデーションで `undergradFaculty` 等が必須チェックされ、ユーザーが入力できないまま進めない状態になっていた。

## 修正ファイル
- `types/profile.ts` — `EnrollmentRecord` に `graduationYear` 追加
- `components/onboarding/types.tsx` — `FormData` に `graduationYear` 追加
- `components/onboarding/step2-enrollment.tsx` — 学府選択時のみ学部在籍セクション表示、卒業年度UI追加
- `components/onboarding-form.tsx` — バリデーション修正、卒業年度の保存・復元対応
- `app/api/profile/route.ts` — `graduationYear` パース追加
- `app/internal/(protected)/profile/page.tsx` — 卒業年度表示追加

## Test plan
- [ ] 卒業生 → 学部を選択 → 「学部に在籍しましたか？」が表示されないことを確認
- [ ] 卒業生 → 学府を選択 → 「学部に在籍しましたか？」が表示されることを確認
- [ ] 卒業生 → 学部を選択 → 卒業年度を入力 → 「次へ」で進めることを確認
- [ ] 卒業年度がプロフィールページに表示されることを確認
- [ ] 院生のフローに影響がないことを確認