### PR TITLE
✨ プロフィール文のplaceholderを改善 & 表示切れを修正

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -336,6 +336,11 @@ body:has(.internal-area) footer.bg-gradient-primary {
   animation: gradient-shift 8s ease-in-out infinite;
 }
 
+/* Markdown editor: ensure placeholder is fully visible */
+.w-md-editor-text {
+  min-height: 100% !important;
+}
+
 /* Reduced motion */
 @media (prefers-reduced-motion: reduce) {
   .animate-spring-up, .animate-soft-pulse, .animate-accent-bar, .animate-gradient,

--- a/components/onboarding/step4-profile.tsx
+++ b/components/onboarding/step4-profile.tsx
@@ -42,8 +42,8 @@ export function Step4Profile({form, setForm, submitting, onNext, onBack}: Step4P
           <MarkdownEditor
             value={form.bio}
             onChange={(val) => setForm((f) => ({...f, bio: val}))}
-            height={200}
-            placeholder={"## 👋 こんにちは！\n\nコーヒーを燃料に動くタイプの人間です。\n\n**好きなこと**\n- 🖥️ Webアプリを作ること（そして壊すこと）\n- 📚 技術書を積むこと（読むとは言ってない）\n- 🎮 深夜のゲーム（翌朝の後悔付き）\n\n> 「動くコードは正義」がモットーです。\n\nよろしくお願いします！"}
+            height={300}
+            placeholder={"経営学部3年の山田です！\n\n**趣味**\n- カラオケ 🎤（ヒトカラも全然いく派）\n- 筋トレ 💪（最近ベンチプレス60kg達成しました）\n- Netflix（おすすめあったら教えてください！）\n\n最近友達とWeb開発や機械学習の勉強を始めました！いろいろ作ってみたいです、よろしくお願いします！"}
           />
         </div>
 

--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -704,7 +704,7 @@ export default function ProfileEdit() {
                         value={profile.bio}
                         onChange={(val) => setProfile({ ...profile, bio: val })}
                         height={200}
-                        placeholder={"## 👋 こんにちは！\n\nコーヒーを燃料に動くタイプの人間です。\n\n**好きなこと**\n- 🖥️ Webアプリを作ること\n- 📚 技術書を積むこと（読むとは言ってない）\n\n> 「動くコードは正義」がモットーです。"}
+                        placeholder={"経営学部3年の山田です！\n\n**趣味**\n- カラオケ 🎤（ヒトカラも全然いく派）\n- 筋トレ 💪（最近ベンチプレス60kg達成しました）\n- Netflix（おすすめあったら教えてください！）\n\n最近友達とWeb開発や機械学習の勉強を始めました！いろいろ作ってみたいです、よろしくお願いします！"}
                       />
                     ) : key === "birthDate" ? (
                       <Input


### PR DESCRIPTION
## Summary
- プロフィール文のplaceholderを親しみやすい内容に変更（趣味・興味分野を含む自然な自己紹介文）
- `@uiw/react-md-editor` の既知バグにより、複数行のplaceholderが途中で切れる問題をCSSワークアラウンドで修正

## 原因
`@uiw/react-md-editor` の `.w-md-editor-text` が値が空の時に `height: 100px` に縮み、`overflow-y: hidden` のためplaceholderの下部が表示されない。
これは [uiwjs/react-md-editor#625](https://github.com/uiwjs/react-md-editor/issues/625) で報告されている既知のバグ。

## 修正内容
- `app/globals.css` — `.w-md-editor-text { min-height: 100% !important; }` を追加
- `components/onboarding/step4-profile.tsx` — placeholder文を変更
- `components/profile-edit.tsx` — 同上

## Test plan
- [ ] オンボーディングStep4でplaceholderが全文表示されることを確認
- [ ] プロフィール編集画面でplaceholderが全文表示されることを確認
- [ ] テキスト入力時にエディタの動作に問題がないことを確認