### PR TITLE
🔧 gh-actions SAにCloud Run SAへのactAs権限を付与

### DIFF
--- a/infra/service_account.tf
+++ b/infra/service_account.tf
@@ -33,3 +33,15 @@ resource "google_project_iam_member" "cloud_run_firebase" {
   member  = "serviceAccount:${google_service_account.cloud_run[each.key].email}"
 }
 
+# ---------------------------------------------------------------------------
+# gh-actions SA → Cloud Run SA の actAs 権限
+# Cloud Run デプロイ時に service_account_name を指定するために必要
+# ---------------------------------------------------------------------------
+resource "google_service_account_iam_member" "gh_actions_act_as_cloud_run" {
+  for_each = toset(local.cloud_run_envs)
+
+  service_account_id = google_service_account.cloud_run[each.key].name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:gh-actions@${var.project_id}.iam.gserviceaccount.com"
+}
+


### PR DESCRIPTION
## 概要
- Cloud Runデプロイ時に `PERMISSION_DENIED: Permission 'iam.serviceaccounts.actAs'` エラーが発生していた問題を修正
- `gh-actions` SAに対して、dev/stg/prd各環境のCloud Run SA (`lumos-web-{env}`) への `roles/iam.serviceAccountUser` を付与

## 原因
Cloud Runサービスが `service_account_name` で各環境用SA を指定しているため、デプロイを実行する `gh-actions` SAにはそれらのSAへの `actAs` 権限が必要だった

## テスト
- [x] `terraform plan` で意図通りの差分を確認
- [x] `terraform apply` 後にCloud Runデプロイが成功することを確認