### PR TITLE
📝 Issue Templateの改善: 全フィールドOptional化・項目簡略化

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,13 +3,17 @@ description: バグや不具合の報告
 title: "[Bug] "
 labels: ["bug"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        該当する項目のみ入力してください。全て任意項目です。
   - type: textarea
     id: summary
     attributes:
       label: バグの概要
       description: どのような問題が発生していますか？
     validations:
-      required: true
+      required: false
   - type: input
     id: url
     attributes:
@@ -17,32 +21,7 @@ body:
       description: バグが発生しているページのURL
       placeholder: https://...
     validations:
-      required: true
-  - type: textarea
-    id: steps
-    attributes:
-      label: 再現手順
-      description: バグを再現する手順を記載してください
-      value: |
-        1.
-        2.
-        3.
-    validations:
-      required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: 期待される動作
-      description: 本来どのように動作すべきですか？
-    validations:
-      required: true
-  - type: textarea
-    id: actual
-    attributes:
-      label: 実際の動作
-      description: 実際にはどのように動作しましたか？
-    validations:
-      required: true
+      required: false
   - type: textarea
     id: screenshots
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,20 +3,24 @@ description: 新機能や改善の提案
 title: "[Feature] "
 labels: ["enhancement"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        該当する項目のみ入力してください。全て任意項目です。
   - type: textarea
     id: summary
     attributes:
       label: 概要
       description: どのような機能を追加・改善したいですか？
     validations:
-      required: true
+      required: false
   - type: textarea
     id: motivation
     attributes:
       label: 背景・動機
       description: なぜこの機能が必要ですか？
     validations:
-      required: true
+      required: false
   - type: textarea
     id: solution
     attributes:

--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -3,13 +3,17 @@ description: サービスへのフィードバックや改善提案
 title: "[Feedback] "
 labels: ["feedback"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        該当する項目のみ入力してください。全て任意項目です。
   - type: textarea
     id: content
     attributes:
       label: フィードバック内容
       description: サービスに対するご意見・ご感想をお聞かせください
     validations:
-      required: true
+      required: false
   - type: input
     id: url
     attributes:

--- a/.github/ISSUE_TEMPLATE/todo.yml
+++ b/.github/ISSUE_TEMPLATE/todo.yml
@@ -3,20 +3,24 @@ description: 開発タスクやリファクタリングなどのTODO
 title: "[TODO] "
 labels: ["todo"]
 body:
+  - type: markdown
+    attributes:
+      value: |
+        該当する項目のみ入力してください。全て任意項目です。
   - type: textarea
     id: task
     attributes:
       label: やること
       description: 何を対応する必要がありますか？
     validations:
-      required: true
+      required: false
   - type: textarea
     id: reason
     attributes:
       label: 背景・理由
       description: なぜこの対応が必要ですか？
     validations:
-      required: true
+      required: false
   - type: textarea
     id: approach
     attributes:


### PR DESCRIPTION
## Summary
- 全テンプレートのフィールドをOptionalに変更
- バグ報告から再現手順・期待される動作・実際の動作を削除し簡略化
- 全テンプレートの先頭に「該当する項目のみ入力してください」の案内を追加