### PR TITLE
🔥 skillsフィールドを削除し、interestsに統合

### DIFF
--- a/app/api/profile/route.ts
+++ b/app/api/profile/route.ts
@@ -100,9 +100,6 @@ export async function PUT(request: Request) {
     ) {
       data.yearByFiscal = body.yearByFiscal as Record<string, string>
     }
-    if (Array.isArray(body.skills) && body.skills.every((s: unknown) => typeof s === "string")) {
-      data.skills = body.skills
-    }
     const VALID_PRIMARY_AVATARS = ["face", "discord", "line", "default"] as const
     if (typeof body.primaryAvatar === "string" && (VALID_PRIMARY_AVATARS as readonly string[]).includes(body.primaryAvatar)) {
       data.primaryAvatar = body.primaryAvatar as typeof VALID_PRIMARY_AVATARS[number]

--- a/app/internal/(protected)/page.tsx
+++ b/app/internal/(protected)/page.tsx
@@ -10,7 +10,7 @@ const QUICK_ACTIONS = [
     href: "/internal/profile/edit",
     icon: Pencil,
     label: "プロフィール編集",
-    description: "自己紹介やスキルを更新",
+    description: "自己紹介や興味タグを更新",
     gradient: "from-purple-500 to-indigo-500",
   },
   {
@@ -54,7 +54,6 @@ function getProfileCompletionItems(member: Record<string, unknown> | null): Comp
     { label: "ニックネーム", done: !!member.nickname },
     { label: "氏名", done: !!member.lastName },
     { label: "プロフィール文", done: !!member.bio },
-    { label: "スキル", done: !!(member.skills && (member.skills as string[]).length > 0) },
     { label: "顔写真", done: !!member.faceImage },
     { label: "SNS連携", done: !!member.github || !!member.x || !!member.line },
     { label: "興味分野", done: !!(member.interests && (member.interests as string[]).length > 0) },

--- a/components/member-detail-shared.tsx
+++ b/components/member-detail-shared.tsx
@@ -41,24 +41,6 @@ export function InterestsSection({ interests }: { interests?: string[] }) {
   )
 }
 
-// --- SkillsSection ---
-
-export function SkillsSection({ skills }: { skills: string[] }) {
-  if (skills.length === 0) return null
-  return (
-    <div className="mb-4">
-      <h4 className="font-bold text-sm text-muted-foreground mb-2">スキル</h4>
-      <div className="flex flex-wrap gap-2">
-        {skills.map((skill, index) => (
-          <span key={index} className="bg-secondary text-primary text-xs px-2 py-1 rounded-full">
-            {skill}
-          </span>
-        ))}
-      </div>
-    </div>
-  )
-}
-
 // --- MemberDetailContent ---
 
 export function MemberDetailContent({ member, showSnsAvatar }: { member: Member; showSnsAvatar?: boolean }) {
@@ -98,7 +80,6 @@ export function MemberDetailContent({ member, showSnsAvatar }: { member: Member;
             <BioSection bio={member.bio} />
           </div>
           <InterestsSection interests={member.interests} />
-          <SkillsSection skills={member.skills} />
           <SnsChipsSection social={member.social} />
         </div>
       </div>

--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -24,7 +24,7 @@ import type { SnsEntry } from "@/components/member-tile-preview"
 import { LiquidSplashEffect } from "@/components/liquid-splash-effect"
 import { InterestTagInput } from "@/components/interest-tag-input"
 
-const FIELD_LABELS: Partial<Record<keyof Omit<Profile, "visibility" | "role" | "year" | "skills" | "enrollments">, string>> = {
+const FIELD_LABELS: Partial<Record<keyof Omit<Profile, "visibility" | "role" | "year" | "enrollments">, string>> = {
   studentId: "学籍番号",
   nickname: "ニックネーム",
   lastName: "姓",
@@ -60,7 +60,7 @@ const VISIBILITY_LABELS: Record<string, string> = {
 
 const VISIBILITY_DISPLAY_KEYS = ["lastName", "faculty", "currentOrg", "birthDate", "gender", "nickname", "bio", "discord", "line", "github", "x", "linkedin"] as const
 
-const PROFILE_FIELDS = Object.keys(FIELD_LABELS) as Array<keyof Omit<Profile, "visibility" | "role" | "year" | "skills" | "enrollments">>
+const PROFILE_FIELDS = Object.keys(FIELD_LABELS) as Array<keyof Omit<Profile, "visibility" | "role" | "year" | "enrollments">>
 
 const DEFAULT_PROFILE: Profile = {
   studentId: "",

--- a/lib/members.ts
+++ b/lib/members.ts
@@ -21,7 +21,6 @@ export interface MemberDocument {
   currentOrg?: string        // 卒業生の現在の所属
   birthDate?: string         // YYYY-MM-DD
   gender?: string
-  skills?: string[]
   github?: string
   githubId?: string
   githubAvatar?: string
@@ -260,7 +259,6 @@ export function profileToMember(discordId: string, data: MemberDocument): Member
     department: v.faculty === 'public' ? currentFaculty : '',
     year: data.yearByFiscal?.[String(new Date().getFullYear())] ?? '',
     bio: v.bio === 'public' ? data.bio : '',
-    skills: data.skills ?? [],
     image: resolvePrimaryAvatar(discordId, data),
     social: Object.keys(social).length > 0 ? social : undefined,
     nickname: v.nickname === 'public' ? data.nickname || undefined : undefined,
@@ -303,7 +301,6 @@ export function profileToMemberInternal(discordId: string, data: MemberDocument)
     department: v.faculty !== 'private' ? currentFaculty : '',
     year: data.yearByFiscal?.[String(new Date().getFullYear())] ?? '',
     bio: v.bio !== 'private' ? data.bio : '',
-    skills: data.skills ?? [],
     image: resolveDiscordAvatar(discordId, data.discordAvatar),
     faceImage: data.faceImage || undefined,
     snsAvatar,

--- a/types/member.ts
+++ b/types/member.ts
@@ -5,7 +5,6 @@ export type Member = {
   department: string
   year: string
   bio: string
-  skills: string[]
   image: string
   faceImage?: string   // GCS URL (顔写真)
   snsAvatar?: string   // Discord or LINE アバター (内部メンバー表示用)

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -44,7 +44,6 @@ export interface Profile {
   x: string
   role?: string
   year?: string
-  skills?: string[]
   interests?: string[]
   topInterests?: string[]
   visibility: ProfileVisibility


### PR DESCRIPTION
## Summary
- `skills` フィールドを全箇所から削除（型定義、API、表示コンポーネント、完成度チェック）
- `skills` は編集UIがなく `interests`（興味分野）と役割が重複していたため統合

Mentions #93

## Test plan
- [ ] プロフィール完成度チェックリストに「スキル」が表示されないこと
- [ ] メンバー詳細ページで「スキル」セクションが表示されないこと
- [ ] プロフィール編集・保存が正常に動作すること
- [ ] TypeScriptビルドエラーがないこと