### PR TITLE
♻️ メンバー種別「聴講生」を「その他」に変更

### DIFF
--- a/components/member-search.tsx
+++ b/components/member-search.tsx
@@ -11,7 +11,7 @@ const MEMBER_TYPE_FILTERS = [
   { key: "all", label: "すべて" },
   { key: "学部生", label: "学部生" },
   { key: "院生", label: "院生" },
-  { key: "聴講生", label: "聴講生" },
+  { key: "その他", label: "その他" },
   { key: "卒業生", label: "卒業生" },
 ]
 

--- a/components/onboarding/step2-enrollment.tsx
+++ b/components/onboarding/step2-enrollment.tsx
@@ -60,6 +60,11 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
             ))}
           </div>
           {step2Errors.memberType && <p className="text-xs text-red-500">{step2Errors.memberType}</p>}
+          {form.memberType === "その他" && (
+            <div className="mt-2 rounded-lg border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/30 px-4 py-3 text-sm text-teal-800 dark:text-teal-300">
+              研究生・科目等履修生・聴講生などが該当します。
+            </div>
+          )}
         </div>
 
         {/* 学年 */}

--- a/components/onboarding/types.tsx
+++ b/components/onboarding/types.tsx
@@ -117,7 +117,7 @@ export function getSchoolYearOptions(memberType: MemberType | ""): { label: stri
       return {label: "学年", options: ["学部1年", "学部2年", "学部3年", "学部4年"]}
     case "院生":
       return {label: "学年", options: ["修士1年", "修士2年", "博士1年", "博士2年", "博士3年"]}
-    case "聴講生":
+    case "その他":
       return {
         label: "学年",
         note: "在籍した年数を選択してください",

--- a/types/member.ts
+++ b/types/member.ts
@@ -17,7 +17,7 @@ export type Member = {
     website?: string
   }
   nickname?: string          // ニックネーム（visibility に従う）
-  memberType?: string        // 学部生/院生/聴講生/卒業生
+  memberType?: string        // 学部生/院生/その他/卒業生
   currentOrg?: string        // 卒業生の現在の所属
   gender?: string            // 性別
   ringColor?: string         // リングカラーキー
@@ -49,7 +49,7 @@ export function getRingColorClass(key?: string): string {
 /**
  * バッジに表示するラベルを返す。
  * 学部生/院生 → 学年テキストそのまま（例: "学部3年", "修士2年"）
- * 聴講生 → "聴講生 X年"
+ * その他 → "その他 X年"
  * 卒業生 → "卒業生"
  */
 export function getMemberTypeBadgeLabel(memberType?: string, year?: string): string {
@@ -58,8 +58,8 @@ export function getMemberTypeBadgeLabel(memberType?: string, year?: string): str
     case "学部生":
     case "院生":
       return year || memberType
-    case "聴講生":
-      return year ? `聴講生 ${year}` : memberType
+    case "その他":
+      return year ? `その他 ${year}` : memberType
     default:
       return memberType
   }
@@ -77,7 +77,7 @@ export function getMemberTypeBadgeClass(type: string): string {
     case "学部生": return "bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300"
     case "院生":   return "bg-purple-100 text-purple-700 dark:bg-purple-900/40 dark:text-purple-300"
     case "卒業生": return "bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400"
-    case "聴講生": return "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300"
+    case "その他": return "bg-teal-100 text-teal-700 dark:bg-teal-900/40 dark:text-teal-300"
     default:       return "bg-gray-100 text-gray-600"
   }
 }

--- a/types/profile.ts
+++ b/types/profile.ts
@@ -52,7 +52,7 @@ export interface Profile {
 
 export const GENDER_OPTIONS = ["男性", "女性", "その他"] as const
 
-export const MEMBER_TYPES = ["学部生", "院生", "聴講生", "卒業生"] as const
+export const MEMBER_TYPES = ["学部生", "院生", "その他", "卒業生"] as const
 export type MemberType = typeof MEMBER_TYPES[number]
 
 export const ENROLLMENT_TYPES = ["入学", "編入"] as const
@@ -72,7 +72,7 @@ export function getFacultyOptions(memberType: MemberType | ""): { label: string;
       return { label: "所属学部", options: FACULTIES }
     case "院生":
       return { label: "所属学府", options: GRADUATE_SCHOOLS }
-    case "聴講生":
+    case "その他":
       return { label: "所属学部/学府", options: [...FACULTIES, ...GRADUATE_SCHOOLS] }
     case "卒業生":
       return { label: "最終所属学部/学府", options: [...FACULTIES, ...GRADUATE_SCHOOLS] }


### PR DESCRIPTION
## Summary
- メンバー種別の「聴講生」を「その他」にリネーム（研究生・科目等履修生等も含むため）
- オンボーディングで「その他」選択時に該当例（研究生・科目等履修生・聴講生）を示すcalloutを追加
- 型定義、バッジ表示、検索フィルター、オンボーディングの全箇所を一括変更

Resolves #86

## Test plan
- [ ] オンボーディングStep2で「その他」ボタンが表示され、選択時にcalloutが出ること
- [ ] メンバー一覧のフィルターに「その他」が表示されること
- [ ] メンバー詳細のバッジに「その他」と表示されること
- [ ] TypeScriptビルドエラーがないこと