### PR TITLE
🐛 テーマ初期化スクリプトのhydrationエラーを修正

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type React from "react"
 import type { Metadata } from "next"
+import Script from "next/script"
 import { Noto_Sans_JP } from "next/font/google"
 import "./globals.css"
 import Header from "@/components/header"
@@ -58,7 +59,9 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <head>
-        <script
+        <Script
+          id="theme-init"
+          strategy="beforeInteractive"
           dangerouslySetInnerHTML={{
             __html: `(function(){try{var t=localStorage.getItem("theme")||"light";if(t==="system")t=matchMedia("(prefers-color-scheme:dark)").matches?"dark":"light";document.documentElement.classList.add(t);document.documentElement.style.colorScheme=t}catch(e){}})()`,
           }}


### PR DESCRIPTION
## 概要
`app/layout.tsx`でインラインの`<script>`タグを使用していたため、React 19 / Next.js 16環境で以下のコンソールエラーが発生していました：

- `Encountered a script tag while rendering React component`（スクリプトが実行されない）
- Hydration mismatch

## 変更内容
- `<script dangerouslySetInnerHTML>` → `next/script`の`<Script strategy="beforeInteractive">`に置き換え
- テーマ初期化のタイミングは`beforeInteractive`で維持されるため、フラッシュ防止の動作は変わりません

## テスト
- [ ] ダークモード/ライトモード切り替えが正常に動作すること
- [ ] ページ読み込み時にテーマのフラッシュが発生しないこと
- [ ] コンソールにscriptタグ関連のエラーが出ないこと