### PR TITLE
🐛 LinkedInチップのURLエンコード文字列をデコードして表示

### DIFF
--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -459,7 +459,8 @@ export default function ProfileEdit() {
     if (check(v.x) && profile.x)
       entries.push({ platform: "x", username: profile.x, url: `https://x.com/${profile.x}`, avatarUrl: xAvatar || undefined })
     if (check(v.linkedin) && linkedinUrl) {
-      const vanity = linkedinUrl.match(/linkedin\.com\/in\/([^/?#]+)/)?.[1] ?? "LinkedIn"
+      const rawVanity = linkedinUrl.match(/linkedin\.com\/in\/([^/?#]+)/)?.[1] ?? "LinkedIn"
+      const vanity = decodeURIComponent(rawVanity)
       entries.push({ platform: "linkedin", username: vanity, url: linkedinUrl })
     }
     return entries

--- a/components/sns-chips.tsx
+++ b/components/sns-chips.tsx
@@ -189,7 +189,8 @@ export function socialToSnsEntries(social?: SocialInput): SnsEntry[] {
   if (social.linkedin) {
     const normalized = normalizeLinkedInUrl(social.linkedin)
     const url = normalized ?? social.linkedin
-    const username = url.replace(/^https?:\/\/(www\.)?linkedin\.com\/in\//, "").replace(/\/$/, "")
+    const raw = url.replace(/^https?:\/\/(www\.)?linkedin\.com\/in\//, "").replace(/\/$/, "")
+    const username = decodeURIComponent(raw)
     entries.push({ platform: "linkedin", username, url })
   }
   return entries


### PR DESCRIPTION
## Summary
- LinkedInのURLに日本語等が含まれている場合、chipに `%E5%B1%B1%E7%94%B0` のようなURLエンコード文字列がそのまま表示されていた問題を修正
- `sns-chips.tsx` と `profile-edit.tsx` の2箇所で、抽出したユーザー名に `decodeURIComponent()` を適用

## Test plan
- [ ] 日本語を含むLinkedIn URL（例: `https://www.linkedin.com/in/山田太郎`）でchipにデコードされた文字列が表示されることを確認
- [ ] ASCII文字のみのLinkedIn URLで既存動作に影響がないことを確認