### PR TITLE
✨ プロフィール編集画面に種別・学年の変更フィールドを追加

### DIFF
--- a/app/internal/(protected)/profile/page.tsx
+++ b/app/internal/(protected)/profile/page.tsx
@@ -10,12 +10,7 @@ import {BioSection, InterestsSection} from "@/components/member-detail-shared"
 import {SnsChipsSection} from "@/components/sns-chips"
 import {getRingColorClass} from "@/types/member"
 import type {Member} from "@/types/member"
-
-function formatBirthDate(d: string) {
-  const parts = d.split("-")
-  if (parts.length >= 3) return `${parseInt(parts[1])}月${parseInt(parts[2])}日`
-  return d
-}
+import {formatBirthDate} from "@/lib/date"
 
 export default async function ProfilePage() {
   const session = await auth()

--- a/components/member-detail-shared.tsx
+++ b/components/member-detail-shared.tsx
@@ -5,6 +5,7 @@ import { DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/di
 import type { Member } from "@/types/member"
 import { getRingColorClass, getMemberTypeBadgeClass, getMemberTypeBadgeLabel, getTileDisplay } from "@/types/member"
 import { SnsChipsSection } from "@/components/sns-chips"
+import { formatBirthDate } from "@/lib/date"
 
 // --- BioSection ---
 
@@ -87,6 +88,11 @@ export function MemberDetailContent({ member }: { member: Member }) {
             </DialogDescription>
           </DialogHeader>
           <div className="mt-3 space-y-3">
+            {member.birthDate && (
+              <p className="text-sm text-muted-foreground">
+                <span className="font-medium text-foreground">誕生日:</span> {formatBirthDate(member.birthDate)}
+              </p>
+            )}
             <InterestsSection interests={member.interests} />
             <SnsChipsSection social={member.social} />
           </div>

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -91,6 +91,7 @@ export default function OnboardingForm() {
     step2TimerRef.current = setTimeout(() => {
       try {
         localStorage.setItem(step2CacheKey, JSON.stringify({
+          studentId: f.studentId,
           memberType: f.memberType,
           schoolYear: f.schoolYear,
           faculty: f.faculty,
@@ -144,7 +145,7 @@ export default function OnboardingForm() {
             firstName: data.firstName ?? "",
             lastNameRomaji: data.lastNameRomaji ?? "",
             firstNameRomaji: data.firstNameRomaji ?? "",
-            studentId: data.studentId ?? "",
+            studentId: data.studentId || cache.studentId || "",
             birthDate: data.birthDate ?? "",
             gender: data.gender ?? "",
             nickname: data.nickname ?? "",
@@ -254,7 +255,6 @@ export default function OnboardingForm() {
         method: "PUT",
         headers: {"Content-Type": "application/json"},
         body: JSON.stringify({
-          studentId: data.studentId,
           lastName: data.lastName,
           firstName: data.firstName,
           lastNameRomaji: data.lastNameRomaji,
@@ -310,11 +310,6 @@ export default function OnboardingForm() {
     } else if (!/^[A-Za-z\s-]+$/.test(form.firstNameRomaji.trim())) {
       errors.firstNameRomaji = "ローマ字（半角英字）で入力してください"
     }
-    if (!form.studentId.trim()) {
-      errors.studentId = "学籍番号を入力してください"
-    } else if (!/^\d{2}[A-Z0-9]{2}\d{3}$/.test(form.studentId.trim())) {
-      errors.studentId = "学籍番号の形式が正しくありません（例: 2164078 / 24HJ078）"
-    }
     if (!form.gender) errors.gender = "性別を選択してください"
     setStep1Errors(errors)
     if (Object.keys(errors).length > 0) return
@@ -361,6 +356,7 @@ export default function OnboardingForm() {
         headers: {"Content-Type": "application/json"},
         body: JSON.stringify({
           memberType: data.memberType,
+          ...(data.memberType !== "卒業生" && data.studentId ? { studentId: data.studentId } : {}),
           yearByFiscal: data.schoolYear ? {[String(new Date().getFullYear())]: data.schoolYear} : undefined,
           currentOrg: data.currentOrg,
           enrollments,
@@ -391,7 +387,14 @@ export default function OnboardingForm() {
   const handleStep2Next = async () => {
     const errors: Partial<Record<keyof FormData, string>> = {}
     if (!form.memberType) errors.memberType = "種別を選択してください"
-    if (form.memberType && form.memberType !== "卒業生" && !form.schoolYear) errors.schoolYear = "学年を選択してください"
+    if (form.memberType && form.memberType !== "卒業生") {
+      if (!form.studentId.trim()) {
+        errors.studentId = "学籍番号を入力してください"
+      } else if (!/^\d{2}[A-Z0-9]{2}\d{3}$/.test(form.studentId.trim())) {
+        errors.studentId = "学籍番号の形式が正しくありません（例: 2164078 / 24HJ078）"
+      }
+      if (!form.schoolYear) errors.schoolYear = "学年を選択してください"
+    }
     if (!form.faculty) errors.faculty = "学部/学府を選択してください"
     if (!form.admissionYear) errors.admissionYear = "入学年度を選択してください"
     if (form.memberType === "卒業生" && !form.graduationYear) errors.graduationYear = "卒業年度を選択してください"

--- a/components/onboarding/step1-basic-info.tsx
+++ b/components/onboarding/step1-basic-info.tsx
@@ -109,23 +109,6 @@ export function Step1BasicInfo({form, setForm, step1Errors, setStep1Errors, subm
         </div>
 
         <div className="space-y-1.5 animate-[fadeInUp_300ms_120ms_ease_both]">
-          <Label htmlFor="studentId">
-            学籍番号 <span className="text-red-500">*</span>
-          </Label>
-          <Input
-            id="studentId"
-            value={form.studentId}
-            onChange={(e) => {
-              setForm((f) => ({...f, studentId: e.target.value.toUpperCase()}))
-              if (step1Errors.studentId) setStep1Errors((p) => ({...p, studentId: undefined}))
-            }}
-            placeholder="2164078 / 24HJ078"
-            className={step1Errors.studentId ? "border-red-400" : ""}
-          />
-          {step1Errors.studentId && <p className="text-xs text-red-500">{step1Errors.studentId}</p>}
-        </div>
-
-        <div className="space-y-1.5 animate-[fadeInUp_300ms_180ms_ease_both]">
           <Label htmlFor="birthDate">誕生日</Label>
           <Input
             id="birthDate"

--- a/components/onboarding/step2-enrollment.tsx
+++ b/components/onboarding/step2-enrollment.tsx
@@ -60,6 +60,24 @@ export function Step2Enrollment({form, setFormStep2, step2Errors, setStep2Errors
             ))}
           </div>
           {step2Errors.memberType && <p className="text-xs text-red-500">{step2Errors.memberType}</p>}
+          {form.memberType && form.memberType !== "卒業生" && (
+            <div className="mt-3 space-y-1.5">
+              <Label htmlFor="studentId">
+                学籍番号 <span className="text-red-500">*</span>
+              </Label>
+              <Input
+                id="studentId"
+                value={form.studentId}
+                onChange={(e) => {
+                  setFormStep2((f) => ({...f, studentId: e.target.value.toUpperCase()}))
+                  if (step2Errors.studentId) setStep2Errors((p) => ({...p, studentId: undefined}))
+                }}
+                placeholder="2164078 / 24HJ078"
+                className={step2Errors.studentId ? "border-red-400" : ""}
+              />
+              {step2Errors.studentId && <p className="text-xs text-red-500">{step2Errors.studentId}</p>}
+            </div>
+          )}
           {form.memberType === "その他" && (
             <div className="mt-2 rounded-lg border border-teal-200 dark:border-teal-800 bg-teal-50 dark:bg-teal-900/30 px-4 py-3 text-sm text-teal-800 dark:text-teal-300">
               研究生・科目等履修生・聴講生などが該当します。

--- a/components/onboarding/types.tsx
+++ b/components/onboarding/types.tsx
@@ -119,9 +119,9 @@ export function getSchoolYearOptions(memberType: MemberType | ""): { label: stri
       return {label: "学年", options: ["修士1年", "修士2年", "博士1年", "博士2年", "博士3年"]}
     case "その他":
       return {
-        label: "学年",
+        label: "在籍年数",
         note: "在籍した年数を選択してください",
-        options: ["1年", "2年", "3年", "4年", "5年", "6年"]
+        options: ["1年目", "2年目", "3年目", "4年目", "5年目", "6年目"]
       }
     default:
       return {label: "学年", options: []}

--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -14,8 +14,10 @@ import { cropAndResizeImage } from "@/lib/image-crop"
 import Cropper from "react-easy-crop"
 import type { Area } from "react-easy-crop"
 import Link from "next/link"
-import type { Profile, VisibilityLevel } from "@/types/profile"
-import { GENDER_OPTIONS } from "@/types/profile"
+import type { Profile, VisibilityLevel, MemberType } from "@/types/profile"
+import { GENDER_OPTIONS, MEMBER_TYPES, ENROLLMENT_TYPES, ADMISSION_YEARS, FACULTIES, GRADUATE_SCHOOLS, getFacultyOptions } from "@/types/profile"
+import type { EnrollmentType } from "@/types/profile"
+import { getSchoolYearOptions } from "@/components/onboarding/types"
 import { DEFAULT_RING_COLOR, getRingColorClass } from "@/types/member"
 import type { RingColorKey } from "@/types/member"
 import { RingColorPicker } from "@/components/ring-color-picker"
@@ -94,6 +96,15 @@ const DEFAULT_PROFILE: Profile = {
 
 const VISIBILITY_FIELD_KEYS = ["nickname", "lastName", "firstName", "faculty", "currentOrg", "birthDate", "gender", "bio", "discord", "line", "github", "x", "linkedin"] as const
 
+type EnrollmentCache = {
+  year: string; faculty: string; admissionYear: string
+  enrollmentType: EnrollmentType | ""; transferYear: string
+  graduationYear: string; currentOrg: string
+  hasUndergrad: boolean | null; undergradFaculty: string
+  undergradAdmissionYear: string; undergradEnrollmentType: EnrollmentType | ""
+  undergradTransferYear: string
+}
+
 export default function ProfileEdit() {
   const [showPreview, setShowPreview] = useState(false)
   const [profile, setProfile] = useState<Profile>(DEFAULT_PROFILE)
@@ -119,8 +130,17 @@ export default function ProfileEdit() {
   const [faculty, setFaculty] = useState("")
   const [year, setYear] = useState("")
   const [role, setRole] = useState("")
-  const [memberType, setMemberType] = useState("")
+  const [memberType, setMemberType] = useState<MemberType | "">("")
   const [currentOrg, setCurrentOrg] = useState("")
+  const [admissionYear, setAdmissionYear] = useState("")
+  const [enrollmentType, setEnrollmentType] = useState<EnrollmentType | "">("")
+  const [transferYear, setTransferYear] = useState("")
+  const [graduationYear, setGraduationYear] = useState("")
+  const [hasUndergrad, setHasUndergrad] = useState<boolean | null>(null)
+  const [undergradFaculty, setUndergradFaculty] = useState("")
+  const [undergradAdmissionYear, setUndergradAdmissionYear] = useState("")
+  const [undergradEnrollmentType, setUndergradEnrollmentType] = useState<EnrollmentType | "">("")
+  const [undergradTransferYear, setUndergradTransferYear] = useState("")
   const [interests, setInterests] = useState<string[]>([])
   const [topInterests, setTopInterests] = useState<string[]>([])
   const [bannerImageUrl, setBannerImageUrl] = useState("")
@@ -132,6 +152,9 @@ export default function ProfileEdit() {
   const fileInputRef = useRef<HTMLInputElement>(null)
   const bannerFileInputRef = useRef<HTMLInputElement>(null)
   const initialSnapshot = useRef<string>("")
+
+  // 種別ごとの所属情報キャッシュ（種別切り替え時に退避・復元）
+  const enrollmentCacheRef = useRef<Partial<Record<string, EnrollmentCache>>>({})
 
   useEffect(() => {
     fetch("/api/profile")
@@ -161,8 +184,24 @@ export default function ProfileEdit() {
             const hasPublic = VISIBILITY_FIELD_KEYS.some((k) => vis[k] === "public")
             setAllowPublic(hasPublic)
           }
-          const currentFaculty = data.enrollments?.find((e: { isCurrent?: boolean }) => e.isCurrent)?.faculty ?? ""
-          setFaculty(currentFaculty)
+          const currentEnrollment = data.enrollments?.find((e: { isCurrent?: boolean }) => e.isCurrent)
+          setFaculty(currentEnrollment?.faculty ?? "")
+          setAdmissionYear(currentEnrollment?.admissionYear ?? "")
+          setEnrollmentType((currentEnrollment?.enrollmentType as EnrollmentType) ?? "")
+          setTransferYear(currentEnrollment?.transferYear ?? "")
+          setGraduationYear(currentEnrollment?.graduationYear ?? "")
+          const undergradEnrollment = data.enrollments?.find((e: { isCurrent?: boolean }) => !e.isCurrent)
+          if (data.memberType === "院生" || (data.memberType === "卒業生" && (GRADUATE_SCHOOLS as readonly string[]).includes(currentEnrollment?.faculty ?? ""))) {
+            if (undergradEnrollment) {
+              setHasUndergrad(true)
+              setUndergradFaculty(undergradEnrollment.faculty ?? "")
+              setUndergradAdmissionYear(undergradEnrollment.admissionYear ?? "")
+              setUndergradEnrollmentType((undergradEnrollment.enrollmentType as EnrollmentType) ?? "")
+              setUndergradTransferYear(undergradEnrollment.transferYear ?? "")
+            } else if (data.enrollments?.length > 0) {
+              setHasUndergrad(false)
+            }
+          }
           const fiscalYear = new Date().getMonth() >= 3 ? new Date().getFullYear() : new Date().getFullYear() - 1
           setYear(data.yearByFiscal?.[String(fiscalYear)] ?? "")
           setRole(data.role ?? "")
@@ -177,7 +216,7 @@ export default function ProfileEdit() {
           if (data.bannerImage) setBannerImageUrl(data.bannerImage)
           if (data.primaryAvatar) setPrimaryAvatar(data.primaryAvatar)
           if (data.ringColor) setRingColor(data.ringColor)
-          if (data.memberType) setMemberType(data.memberType)
+          if (data.memberType && (MEMBER_TYPES as readonly string[]).includes(data.memberType)) setMemberType(data.memberType as MemberType)
           if (data.currentOrg) setCurrentOrg(data.currentOrg)
           if (data.interests) setInterests(data.interests)
           if (data.topInterests) setTopInterests(data.topInterests)
@@ -208,6 +247,17 @@ export default function ProfileEdit() {
             topInterests: data.topInterests ?? [],
             memberType: data.memberType ?? "",
             currentOrg: data.currentOrg ?? "",
+            year: data.yearByFiscal?.[String(fiscalYear)] ?? "",
+            faculty: currentEnrollment?.faculty ?? "",
+            admissionYear: currentEnrollment?.admissionYear ?? "",
+            enrollmentType: currentEnrollment?.enrollmentType ?? "",
+            transferYear: currentEnrollment?.transferYear ?? "",
+            graduationYear: currentEnrollment?.graduationYear ?? "",
+            hasUndergrad: undergradEnrollment ? true : (data.enrollments?.length > 0 ? false : null),
+            undergradFaculty: undergradEnrollment?.faculty ?? "",
+            undergradAdmissionYear: undergradEnrollment?.admissionYear ?? "",
+            undergradEnrollmentType: undergradEnrollment?.enrollmentType ?? "",
+            undergradTransferYear: undergradEnrollment?.transferYear ?? "",
           })
         }
       })
@@ -216,8 +266,8 @@ export default function ProfileEdit() {
   }, [])
 
   const currentSnapshot = useMemo(() =>
-    JSON.stringify({ profile, allowPublic, primaryAvatar, ringColor, interests, topInterests, memberType, currentOrg }),
-    [profile, allowPublic, primaryAvatar, ringColor, interests, topInterests, memberType, currentOrg]
+    JSON.stringify({ profile, allowPublic, primaryAvatar, ringColor, interests, topInterests, memberType, currentOrg, year, faculty, admissionYear, enrollmentType, transferYear, graduationYear, hasUndergrad, undergradFaculty, undergradAdmissionYear, undergradEnrollmentType, undergradTransferYear }),
+    [profile, allowPublic, primaryAvatar, ringColor, interests, topInterests, memberType, currentOrg, year, faculty, admissionYear, enrollmentType, transferYear, graduationYear, hasUndergrad, undergradFaculty, undergradAdmissionYear, undergradEnrollmentType, undergradTransferYear]
   )
 
   const isDirty = !loading && initialSnapshot.current !== "" && currentSnapshot !== initialSnapshot.current
@@ -238,7 +288,39 @@ export default function ProfileEdit() {
       const response = await fetch("/api/profile", {
         method: "PUT",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ ...profile, allowPublic, primaryAvatar, ringColor, interests, topInterests }),
+        body: JSON.stringify({
+          ...profile,
+          allowPublic,
+          primaryAvatar,
+          ringColor,
+          interests,
+          topInterests,
+          memberType,
+          currentOrg: memberType === "卒業生" ? currentOrg : "",
+          ...(memberType !== "卒業生" && year ? {
+            yearByFiscal: { [String(new Date().getMonth() >= 3 ? new Date().getFullYear() : new Date().getFullYear() - 1)]: year },
+          } : {}),
+          ...(() => {
+            const entries = [
+              ...(faculty ? [{
+                faculty,
+                admissionYear,
+                enrollmentType: enrollmentType || "入学",
+                ...(transferYear ? { transferYear } : {}),
+                ...(graduationYear ? { graduationYear } : {}),
+                isCurrent: true,
+              }] : []),
+              ...((memberType === "院生" || (memberType === "卒業生" && (GRADUATE_SCHOOLS as readonly string[]).includes(faculty))) && hasUndergrad && undergradFaculty ? [{
+                faculty: undergradFaculty,
+                admissionYear: undergradAdmissionYear,
+                enrollmentType: undergradEnrollmentType || "入学",
+                ...(undergradTransferYear ? { transferYear: undergradTransferYear } : {}),
+                isCurrent: false,
+              }] : []),
+            ]
+            return entries.length > 0 ? { enrollments: entries } : {}
+          })(),
+        }),
       })
 
       if (response.ok) {
@@ -666,8 +748,299 @@ export default function ProfileEdit() {
               />
             </div>
 
+            {/* 所属情報セクション */}
+            <div className="space-y-4 rounded-xl border border-gray-200 dark:border-gray-700 p-4">
+              <Label className="text-base font-semibold">所属情報</Label>
+
+              {/* 種別 */}
+              <div className="space-y-1.5">
+                <Label>種別</Label>
+                <div className="flex gap-2 flex-wrap">
+                  {MEMBER_TYPES.map((type) => (
+                    <button
+                      key={type}
+                      type="button"
+                      onClick={() => {
+                        if (type === memberType) return
+                        // 現在の種別の情報をキャッシュに退避
+                        if (memberType) {
+                          enrollmentCacheRef.current[memberType] = {
+                            year, faculty, admissionYear, enrollmentType, transferYear,
+                            graduationYear, currentOrg,
+                            hasUndergrad, undergradFaculty, undergradAdmissionYear,
+                            undergradEnrollmentType, undergradTransferYear,
+                          }
+                        }
+                        // キャッシュから復元、なければ空
+                        const cached = enrollmentCacheRef.current[type]
+                        setMemberType(type)
+                        setYear(cached?.year ?? "")
+                        setFaculty(cached?.faculty ?? "")
+                        setAdmissionYear(cached?.admissionYear ?? "")
+                        setEnrollmentType(cached?.enrollmentType ?? "")
+                        setTransferYear(cached?.transferYear ?? "")
+                        setGraduationYear(cached?.graduationYear ?? "")
+                        setCurrentOrg(cached?.currentOrg ?? "")
+                        setProfile((p) => ({ ...p, currentOrg: cached?.currentOrg ?? "" }))
+                        setHasUndergrad(cached?.hasUndergrad ?? null)
+                        setUndergradFaculty(cached?.undergradFaculty ?? "")
+                        setUndergradAdmissionYear(cached?.undergradAdmissionYear ?? "")
+                        setUndergradEnrollmentType(cached?.undergradEnrollmentType ?? "")
+                        setUndergradTransferYear(cached?.undergradTransferYear ?? "")
+                      }}
+                      className={[
+                        "px-4 py-2 rounded-full text-sm font-medium border transition-all duration-200",
+                        memberType === type
+                          ? "bg-gradient-to-r from-purple-600 to-indigo-600 text-white border-purple-600"
+                          : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                      ].join(" ")}
+                    >
+                      {type}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              {/* 学年 */}
+              {memberType && memberType !== "卒業生" && (() => {
+                const { label, note, options } = getSchoolYearOptions(memberType)
+                const now = new Date()
+                const fiscalYear = now.getMonth() >= 3 ? now.getFullYear() : now.getFullYear() - 1
+                return (
+                  <div className="space-y-1.5">
+                    <Label>{fiscalYear}年度での{label}</Label>
+                    {note && <p className="text-xs text-muted-foreground">{note}</p>}
+                    <select
+                      value={year}
+                      onChange={(e) => setYear(e.target.value)}
+                      className="block w-full border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                    >
+                      <option value="">選択してください</option>
+                      {options.map((y) => (
+                        <option key={y} value={y}>{y}</option>
+                      ))}
+                    </select>
+                  </div>
+                )
+              })()}
+
+              {/* 学部/学府 */}
+              {memberType && (() => {
+                const { label, options } = getFacultyOptions(memberType)
+                return (
+                  <div className="space-y-1.5">
+                    <Label>{label}</Label>
+                    <select
+                      value={faculty}
+                      onChange={(e) => setFaculty(e.target.value)}
+                      className="block w-full border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                    >
+                      <option value="">選択してください</option>
+                      {options.map((f) => (
+                        <option key={f} value={f}>{f}</option>
+                      ))}
+                    </select>
+                  </div>
+                )
+              })()}
+
+              {/* 入学年度 + 入学/編入 */}
+              {memberType && (
+                <div className="space-y-1.5">
+                  <Label>{memberType === "院生" ? "横浜国立大学大学院への入学年度" : "横浜国立大学への入学年度"}</Label>
+                  <div className="flex gap-2">
+                    <select
+                      value={admissionYear}
+                      onChange={(e) => setAdmissionYear(e.target.value)}
+                      className="flex-1 border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                    >
+                      <option value="">年度を選択</option>
+                      {ADMISSION_YEARS.map((y) => (
+                        <option key={y} value={y}>{y}年度</option>
+                      ))}
+                    </select>
+                    <div className="flex gap-1">
+                      {ENROLLMENT_TYPES.map((type) => (
+                        <button
+                          key={type}
+                          type="button"
+                          onClick={() => {
+                            setEnrollmentType(type)
+                            setTransferYear(type === "編入" ? "3" : "")
+                          }}
+                          className={[
+                            "px-4 py-2 rounded-md text-sm font-medium border transition-all duration-200",
+                            enrollmentType === type
+                              ? "bg-purple-600 text-white border-purple-600"
+                              : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                          ].join(" ")}
+                        >
+                          {type}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {/* 編入年次 */}
+              {enrollmentType === "編入" && (
+                <div className="flex items-center gap-3">
+                  <Label className="whitespace-nowrap text-sm">編入年次</Label>
+                  <div className="flex gap-2">
+                    {["2", "3", "4"].map((y) => (
+                      <button
+                        key={y}
+                        type="button"
+                        onClick={() => setTransferYear(y)}
+                        className={[
+                          "w-12 py-1.5 rounded-full text-sm font-medium border transition-all duration-200",
+                          transferYear === y
+                            ? "bg-purple-600 text-white border-purple-600"
+                            : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                        ].join(" ")}
+                      >
+                        {y}年
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* 卒業生のみ：卒業年度 */}
+              {memberType === "卒業生" && (
+                <div className="space-y-1.5">
+                  <Label>卒業年度</Label>
+                  <select
+                    value={graduationYear}
+                    onChange={(e) => setGraduationYear(e.target.value)}
+                    className="block w-full border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                  >
+                    <option value="">年度を選択</option>
+                    {ADMISSION_YEARS.map((y) => (
+                      <option key={y} value={y}>{y}年度</option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              {/* 院生 or 卒業生（学府卒）：学部進学確認 + 学部時代の情報 */}
+              {(memberType === "院生" || (memberType === "卒業生" && (GRADUATE_SCHOOLS as readonly string[]).includes(faculty))) && (
+                <div className="space-y-4 border-t border-gray-100 dark:border-gray-800 pt-4 mt-2">
+                  <div className="space-y-1.5">
+                    <Label>{memberType === "院生" ? "学部から進学しましたか？" : "学部に在籍しましたか？"}</Label>
+                    <div className="flex gap-2">
+                      {([true, false] as const).map((val) => (
+                        <button
+                          key={String(val)}
+                          type="button"
+                          onClick={() => {
+                            setHasUndergrad(val)
+                            if (!val) {
+                              setUndergradFaculty("")
+                              setUndergradAdmissionYear("")
+                              setUndergradEnrollmentType("")
+                              setUndergradTransferYear("")
+                            }
+                          }}
+                          className={[
+                            "px-5 py-2 rounded-full text-sm font-medium border transition-all duration-200",
+                            hasUndergrad === val
+                              ? "bg-purple-600 text-white border-purple-600"
+                              : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                          ].join(" ")}
+                        >
+                          {val ? "はい" : "いいえ"}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+
+                  {hasUndergrad === true && (
+                    <div className="space-y-4">
+                      <p className="text-sm font-medium text-gray-600 dark:text-gray-400">学部での所属</p>
+
+                      <div className="space-y-1.5">
+                        <Label>所属学部</Label>
+                        <select
+                          value={undergradFaculty}
+                          onChange={(e) => setUndergradFaculty(e.target.value)}
+                          className="block w-full border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                        >
+                          <option value="">選択してください</option>
+                          {FACULTIES.map((f) => (
+                            <option key={f} value={f}>{f}</option>
+                          ))}
+                        </select>
+                      </div>
+
+                      <div className="space-y-1.5">
+                        <Label>学部への入学年度</Label>
+                        <div className="flex gap-2">
+                          <select
+                            value={undergradAdmissionYear}
+                            onChange={(e) => setUndergradAdmissionYear(e.target.value)}
+                            className="flex-1 border rounded-md px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring bg-white dark:bg-gray-800 dark:text-gray-100 border-input dark:border-gray-700"
+                          >
+                            <option value="">年度を選択</option>
+                            {ADMISSION_YEARS.map((y) => (
+                              <option key={y} value={y}>{y}年度</option>
+                            ))}
+                          </select>
+                          <div className="flex gap-1">
+                            {ENROLLMENT_TYPES.map((type) => (
+                              <button
+                                key={type}
+                                type="button"
+                                onClick={() => {
+                                  setUndergradEnrollmentType(type)
+                                  setUndergradTransferYear(type === "編入" ? "3" : "")
+                                }}
+                                className={[
+                                  "px-4 py-2 rounded-md text-sm font-medium border transition-all duration-200",
+                                  undergradEnrollmentType === type
+                                    ? "bg-purple-600 text-white border-purple-600"
+                                    : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                                ].join(" ")}
+                              >
+                                {type}
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      </div>
+
+                      {undergradEnrollmentType === "編入" && (
+                        <div className="flex items-center gap-3">
+                          <Label className="whitespace-nowrap text-sm">編入年次</Label>
+                          <div className="flex gap-2">
+                            {["2", "3", "4"].map((y) => (
+                              <button
+                                key={y}
+                                type="button"
+                                onClick={() => setUndergradTransferYear(y)}
+                                className={[
+                                  "w-12 py-1.5 rounded-full text-sm font-medium border transition-all duration-200",
+                                  undergradTransferYear === y
+                                    ? "bg-purple-600 text-white border-purple-600"
+                                    : "bg-white dark:bg-gray-800 text-gray-600 dark:text-gray-300 border-gray-300 dark:border-gray-600 hover:border-purple-400",
+                                ].join(" ")}
+                              >
+                                {y}年
+                              </button>
+                            ))}
+                          </div>
+                        </div>
+                      )}
+                    </div>
+                  )}
+                </div>
+              )}
+            </div>
+
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               {PROFILE_FIELDS.map((key) => {
+                if (key === "currentOrg" && memberType !== "卒業生") return null
                 const isSns = SNS_FIELDS.has(key)
                 return (
                   <div
@@ -736,7 +1109,10 @@ export default function ProfileEdit() {
                     ) : (
                       <Input
                         value={profile[key] as string ?? ""}
-                        onChange={(e) => setProfile({ ...profile, [key]: e.target.value })}
+                        onChange={(e) => {
+                          setProfile({ ...profile, [key]: e.target.value })
+                          if (key === "currentOrg") setCurrentOrg(e.target.value)
+                        }}
                         placeholder={key === "currentOrg" ? "例: 株式会社〇〇" : `${FIELD_LABELS[key]}を入力してください`}
                       />
                     )}

--- a/lib/date.ts
+++ b/lib/date.ts
@@ -1,0 +1,8 @@
+/**
+ * YYYY-MM-DD 形式の日付を「X月Y日」に変換する
+ */
+export function formatBirthDate(dateStr: string): string {
+  const [, m, d] = dateStr.split("-")
+  if (!m || !d) return dateStr
+  return `${parseInt(m)}月${parseInt(d)}日`
+}

--- a/lib/members.ts
+++ b/lib/members.ts
@@ -330,6 +330,7 @@ export function profileToMemberInternal(discordId: string, data: MemberDocument)
     memberType: data.memberType,
     currentOrg: v.currentOrg !== 'private' ? data.currentOrg || undefined : undefined,
     gender: v.gender !== 'private' ? data.gender || undefined : undefined,
+    birthDate: v.birthDate !== 'private' ? data.birthDate || undefined : undefined,
     ringColor: data.ringColor,
     interests: data.interests ?? [],
     topInterests: data.topInterests ?? [],

--- a/types/member.ts
+++ b/types/member.ts
@@ -25,6 +25,7 @@ export type Member = {
   memberType?: string        // 学部生/院生/その他/卒業生
   currentOrg?: string        // 卒業生の現在の所属
   gender?: string            // 性別
+  birthDate?: string         // 誕生日 (YYYY-MM-DD)
   ringColor?: string         // リングカラーキー
   interests?: string[]       // 興味分野タグ
   topInterests?: string[]    // 一覧表示用Top 3


### PR DESCRIPTION
## Summary
- プロフィール編集画面にonboarding Step2と同等の所属情報セクションを追加
  - 種別（学部生/院生/その他/卒業生）、学年、学部/学府、入学年度、入学/編入、編入年次
  - 院生・卒業生（学府卒）向けの学部進学情報（学部から進学したか、学部時代の所属・入学年度）
  - 卒業年度（卒業生のみ）、現在の所属フィールドを卒業生のみ表示
  - 種別切り替え時に入力情報をキャッシュし、元の種別に戻した際に復元
- onboardingの学籍番号をStep1からStep2に移動（卒業生の場合は非表示）
- 内部メンバー詳細モーダルに誕生日（X月Y日）表示を追加
- 種別「その他」の学年選択肢を「1年, 2年...」→「1年目, 2年目...」に変更

## Test plan
- [ ] プロフィール編集で種別・学年・学部等を変更し保存→リロード後に反映されていることを確認
- [ ] 種別を切り替えて戻した際に、以前の入力情報が復元されることを確認
- [ ] 院生選択時に学部進学情報の入力UIが表示されることを確認
- [ ] 卒業生以外では「現在の所属」フィールドが非表示になることを確認
- [ ] onboardingで卒業生選択時に学籍番号フィールドが表示されないことを確認
- [ ] 内部メンバー詳細モーダルで誕生日が表示されることを確認
- [ ] 種別「その他」で学年が「1年目」等の表記になることを確認