### PR TITLE
プロフィール編集画面の顔写真と公開表示画像セクションを分離

### DIFF
--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -986,6 +986,8 @@ export default function ProfileEdit() {
                 </div>
               </div>
             )}
+
+            <RingColorPicker value={ringColor} onChange={setRingColor} />
           </div>
 
           {/* 公開ページの表示画像セクション */}
@@ -1051,8 +1053,6 @@ export default function ProfileEdit() {
                 </button>
               ))}
             </div>
-
-            <RingColorPicker value={ringColor} onChange={setRingColor} />
           </div>
 
           {/* バナー画像セクション */}


### PR DESCRIPTION
## Summary
- プロフィール編集画面で顔写真アップロードと公開ページ表示画像選択が同一セクション内にまとまっていてわかりづらかったため、2つの独立したボーダー付きセクションに分割
- オンボーディングと同様の顔写真推奨メッセージを顔写真セクションに追加

Closes #127

## Test plan
- [x] `/internal/profile/edit` にアクセスし、顔写真セクションと公開ページ表示画像セクションが別々のボックスとして表示されることを確認
- [x] 顔写真の推奨メッセージが紫色のバナーで表示されることを確認
- [x] 顔写真のアップロード・クロップが正常に動作することを確認
- [x] 公開ページ表示画像の選択（顔写真/Discord/LINE/なし）が正常に動作することを確認
- [x] リングカラー選択が正常に動作することを確認
- [ ] ダークモードで表示が正しいことを確認