### PR TITLE
誕生日の表示をケーキアイコンに変更

### DIFF
--- a/app/internal/(protected)/profile/page.tsx
+++ b/app/internal/(protected)/profile/page.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/member-detail-shared";
 import { SnsChipsSection } from "@/components/sns-chips";
 import { getRingColorClass } from "@/types/member";
+import { Cake } from "lucide-react";
 import type { Member } from "@/types/member";
 import { formatBirthDate } from "@/lib/date";
 
@@ -188,7 +189,8 @@ export default async function ProfilePage() {
                   </p>
                 </div>
                 <div>
-                  <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium">
+                  <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium flex items-center gap-1">
+                    <Cake className="w-3.5 h-3.5" />
                     誕生日
                   </p>
                   <p className="text-sm font-medium mt-0.5">

--- a/components/member-detail-shared.tsx
+++ b/components/member-detail-shared.tsx
@@ -1,4 +1,5 @@
 import Image from "next/image";
+import { Cake } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import {
@@ -123,8 +124,8 @@ export function MemberDetailContent({ member }: { member: Member }) {
           </DialogHeader>
           <div className="mt-3 space-y-3">
             {member.birthDate && (
-              <p className="text-sm text-muted-foreground">
-                <span className="font-medium text-foreground">誕生日:</span>{" "}
+              <p className="text-sm text-muted-foreground flex items-center gap-1.5">
+                <Cake className="w-4 h-4 text-gray-400" />
                 {formatBirthDate(member.birthDate)}
               </p>
             )}


### PR DESCRIPTION
## Summary
- プロフィール表示ページとメンバー詳細ダイアログで「誕生日:」テキストをlucide-reactの`Cake`アイコンに置き換え

## Test plan
- [ ] `/internal/profile` で誕生日の横にケーキアイコンが表示されることを確認
- [ ] メンバー一覧からメンバー詳細ダイアログを開き、誕生日の横にケーキアイコンが表示されることを確認
- [ ] ダークモードでアイコンの色が適切であることを確認