### PR TITLE
🐛 /internal ページのユーザアイコンの縁が見切れる問題を修正

### DIFF
--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -56,7 +56,7 @@ export function AppSidebar({
     <Sidebar collapsible="icon">
       <SidebarHeader className="border-b border-sidebar-border p-4 group-data-[collapsible=icon]:p-2">
         <div className="flex items-center gap-3 overflow-hidden group-data-[collapsible=icon]:justify-start">
-          <Avatar className="h-9 w-9 shrink-0 ring-2 ring-sidebar-primary/20 transition-all duration-200 group-data-[collapsible=icon]:h-7 group-data-[collapsible=icon]:w-7">
+          <Avatar className="h-9 w-9 shrink-0 border-2 border-sidebar-primary/20 transition-all duration-200 group-data-[collapsible=icon]:h-7 group-data-[collapsible=icon]:w-7">
             <AvatarImage src={userImage} alt={userName} />
             <AvatarFallback className="bg-sidebar-primary text-sidebar-primary-foreground text-xs font-bold">
               {(memberNickname || userName).charAt(0)}


### PR DESCRIPTION
## Summary

- `/internal` ページ左上のユーザアイコンに適用されていた `ring-2` (CSS `box-shadow`) を `border-2` に変更
- `ring` は要素の外側に描画されるため、Radix UI Avatar の `overflow-hidden` によって縁が見切れていた
- `border` は要素の内側に描画されるため、クリッピングの影響を受けない

closes #113

## Test plan

- [x] `/internal` ページでユーザアイコンの縁が見切れていないことを確認
- [x] サイドバー縮小時（icon モード）でもアイコンの縁が正しく表示されることを確認