### PR TITLE
✨ Discordサーバー未所属時のエラーページを追加

### DIFF
--- a/app/auth-error/layout.tsx
+++ b/app/auth-error/layout.tsx
@@ -1,0 +1,11 @@
+export default function AuthErrorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 bg-[#0d0f1a] overflow-y-auto">
+      {children}
+    </div>
+  );
+}

--- a/app/auth-error/page.tsx
+++ b/app/auth-error/page.tsx
@@ -1,0 +1,5 @@
+import AuthError from "@/components/auth-error";
+
+export default async function AuthErrorPage() {
+  return <AuthError />;
+}

--- a/components/auth-error.tsx
+++ b/components/auth-error.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const LINES = [
+  { text: "Oops!", delay: 0.3 },
+  { text: "Looks like", delay: 0.6 },
+  { text: "invisible dragons", delay: 0.9 },
+  { text: "ain't letting you in", delay: 1.2 },
+];
+
+export default function AuthError() {
+  const router = useRouter();
+  const [countdown, setCountdown] = useState(10);
+
+  useEffect(() => {
+    const interval = setInterval(() => {
+      setCountdown((c) => {
+        if (c <= 1) {
+          clearInterval(interval);
+          return 0;
+        }
+        return c - 1;
+      });
+    }, 1000);
+    return () => clearInterval(interval);
+  }, []);
+
+  useEffect(() => {
+    if (countdown <= 0) {
+      router.push("/");
+    }
+  }, [countdown, router]);
+
+  return (
+    <div className="fixed inset-0 flex flex-col items-center justify-center bg-[#0d0f1a] overflow-hidden">
+      {/* 背景パーティクル */}
+      {[...Array(6)].map((_, i) => (
+        <div
+          key={i}
+          className="absolute rounded-full pointer-events-none animate-[authOrbit_linear_infinite]"
+          style={{
+            width: `${3 + (i % 3) * 2}px`,
+            height: `${3 + (i % 3) * 2}px`,
+            background:
+              i % 2 === 0 ? "rgba(88,101,242,0.3)" : "rgba(130,120,200,0.25)",
+            left: `${12 + i * 14}%`,
+            top: `${20 + ((i * 19) % 55)}%`,
+            animationDuration: `${8 + i * 2}s`,
+            animationDelay: `${i * 0.6}s`,
+          }}
+        />
+      ))}
+
+      {/* 背景グロー */}
+      <div
+        className="absolute w-[500px] h-[500px] rounded-full pointer-events-none animate-[authGlow_5s_ease-in-out_infinite]"
+        style={{
+          background:
+            "radial-gradient(circle, rgba(88,101,242,0.08) 0%, rgba(130,120,200,0.06) 40%, transparent 70%)",
+        }}
+      />
+
+      <div className="relative z-10 flex flex-col items-start w-full max-w-md px-6">
+        {/* アニメーションテキスト */}
+        <h1 className="flex flex-col items-start gap-1">
+          {LINES.map((line) => (
+            <span
+              key={line.text}
+              className="text-3xl sm:text-4xl font-bold text-white tracking-tight animate-[fade-in-up_0.5s_ease_both]"
+              style={{ animationDelay: `${line.delay}s` }}
+            >
+              {line.text}
+            </span>
+          ))}
+          {/* Lumos! — 大きいフォント + 下線アニメーション */}
+          <span
+            className="relative text-[2.5rem] sm:text-5xl font-bold text-white tracking-tight animate-[fade-in-up_0.5s_ease_both]"
+            style={{ animationDelay: "1.5s" }}
+          >
+            Lumos!
+            <span
+              className="absolute bottom-0 left-0 w-full h-[2px] bg-white animate-[authUnderlineDraw_1.5s_ease_both] origin-left"
+              style={{ animationDelay: "1.8s" }}
+            />
+          </span>
+        </h1>
+
+        {/* メッセージ */}
+        <p
+          className="mt-8 text-lg text-[#c8cae0] leading-relaxed animate-[fade-in-up_0.5s_ease_both]"
+          style={{ animationDelay: "2.4s" }}
+        >
+          認証したアカウントが
+          <br />
+          Lumosに存在しているか
+          <br />
+          確認しましょう
+        </p>
+
+        {/* カウントダウン */}
+        <div
+          className="mt-6 animate-[fade-in-up_0.5s_ease_both]"
+          style={{ animationDelay: "3.0s" }}
+        >
+          <p className="text-xs text-[#6b6f8a]">
+            {countdown}秒後にトップへ戻ります
+          </p>
+        </div>
+      </div>
+
+      <style jsx>{`
+        @keyframes authOrbit {
+          0% {
+            transform: translateY(0) translateX(0) scale(1);
+            opacity: 0;
+          }
+          10% {
+            opacity: 0.6;
+          }
+          50% {
+            transform: translateY(-50px) translateX(20px) scale(1.4);
+            opacity: 0.4;
+          }
+          90% {
+            opacity: 0.6;
+          }
+          100% {
+            transform: translateY(0) translateX(0) scale(1);
+            opacity: 0;
+          }
+        }
+        @keyframes authGlow {
+          0%,
+          100% {
+            transform: scale(0.85);
+            opacity: 0.6;
+          }
+          50% {
+            transform: scale(1.15);
+            opacity: 1;
+          }
+        }
+        @keyframes authUnderlineDraw {
+          0% {
+            transform: scaleX(0);
+          }
+          100% {
+            transform: scaleX(1);
+          }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -25,6 +25,7 @@ variable "cloud_run_env_vars" {
       AUTH_LINE_ID          = "2009690509"
 
       AUTH_DISCORD_ID       = "1489548152779309197"
+      DISCORD_GUILD_ID      = "1368752707321729158"
       AUTH_URL              = "https://dev.lumos-ynu.jp"
       FIRESTORE_DATABASE_ID = "development"
       FIREBASE_PROJECT_ID   = "lumos-infra"
@@ -37,6 +38,7 @@ variable "cloud_run_env_vars" {
       AUTH_LINE_ID          = "2009694131"
 
       AUTH_DISCORD_ID       = "1377983265948041228"
+      DISCORD_GUILD_ID      = "1368752707321729158"
       AUTH_URL              = "https://stg.lumos-ynu.jp"
       FIRESTORE_DATABASE_ID = "staging"
       FIREBASE_PROJECT_ID   = "lumos-infra"
@@ -49,6 +51,7 @@ variable "cloud_run_env_vars" {
       AUTH_LINE_ID          = "1661094871"
 
       AUTH_DISCORD_ID       = "933021504319422544"
+      DISCORD_GUILD_ID      = "894226019240800276"
       AUTH_URL              = "https://lumos-ynu.jp"
       FIRESTORE_DATABASE_ID = "" // this should use default db (default)
       FIREBASE_PROJECT_ID   = "lumos-infra"

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -104,7 +104,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
           });
           const guilds = await res.json();
           const isMember = guilds.some((g: { id: string }) => g.id === guildId);
-          return isMember;
+          if (!isMember) return "/auth-error";
+          return true;
         } catch (e) {
           console.error("Failed to fetch guilds", e);
           return false;


### PR DESCRIPTION
## Summary

- Discordログイン時にサーバー未所属の場合、アニメーション付きエラーページ (`/auth-error`) を表示するように変更
- `signIn` コールバックでギルド未所属時に `/auth-error` へリダイレクト（API通信エラーは従来通り `false` を返す）
- 各環境に `DISCORD_GUILD_ID` 環境変数を設定（prd: `894226019240800276`, dev/stg: `1368752707321729158`）
- エラーページは10秒後にトップページへ自動リダイレクト

## Test plan

- [ ] dev環境でDiscordサーバー未所属のアカウントでログインし、エラーページが表示されることを確認
- [ ] エラーページのアニメーション（テキスト順次表示、下線描画）が正しく動作することを確認
- [ ] 10秒後にトップページへ自動リダイレクトされることを確認
- [ ] サーバー所属済みアカウントでは通常通りログインできることを確認