### PR TITLE
🔒 Renovateをセキュリティパッチのみに限定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,3 +1,10 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json"
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
+  "vulnerabilityAlerts": {
+    "enabled": true,
+    "labels": ["security"],
+    "groupName": "security updates",
+    "automerge": true
+  }
 }


### PR DESCRIPTION
## Summary
- 通常の依存性更新PRを無効化し、セキュリティ脆弱性のあるパッチのみを対象に変更
- セキュリティパッチは1つのPRにグループ化され、CI通過後に自動マージされる

## Test plan
- [ ] Renovateがセキュリティアラート以外のPRを作成しないことを確認
- [ ] 脆弱性のある依存性に対してPRが作成されることを確認
- [ ] 自動マージが正しく動作することを確認