### PR TITLE
⚙️ Enable Renovate for security updates only

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,10 +1,24 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "enabled": false,
+  "enabled": true,
+  "dependencyDashboard": false,
+  "schedule": ["at any time"],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
     "groupName": "security updates",
     "automerge": true
-  }
+  },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "enabled": false
+    },
+    {
+      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
+      "matchDatasources": ["npm"],
+      "vulnerabilitySeverity": "low",
+      "enabled": true
+    }
+  ]
 }


### PR DESCRIPTION
Enable Renovate bot configured to only process security vulnerabilities.

Changes:
- Enable Renovate bot
- Configure to only process security vulnerabilities (low severity and above)
- Disable all regular dependency updates (major, minor, patch)
- Disable dependency dashboard
- Keep automerge enabled for security patches

This ensures we get automated PRs only for security issues, not for regular dependency updates.