### PR TITLE
🐛 Fix Renovate config validation error

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,23 +2,15 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "enabled": true,
   "dependencyDashboard": false,
-  "schedule": ["at any time"],
   "vulnerabilityAlerts": {
     "enabled": true,
     "labels": ["security"],
-    "groupName": "security updates",
     "automerge": true
   },
   "packageRules": [
     {
       "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
       "enabled": false
-    },
-    {
-      "matchUpdateTypes": ["major", "minor", "patch", "pin", "digest"],
-      "matchDatasources": ["npm"],
-      "vulnerabilitySeverity": "low",
-      "enabled": true
     }
   ]
 }


### PR DESCRIPTION
Fixes the invalid configuration that was preventing Renovate from running.

**Issue:**
The previous config included `vulnerabilitySeverity` which is not a valid option in `packageRules`.

**Changes:**
- Remove invalid `vulnerabilitySeverity` option
- Remove unnecessary `schedule` and `groupName` from top level
- Simplify config to only use `vulnerabilityAlerts` for security updates

The `vulnerabilityAlerts` setting will automatically handle security updates from GitHub Security Advisories.