### PR TITLE
✨ 継続メンバー向け会費通知モーダルを追加

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,9 @@ DISCORD_BOT_TOKEN="YOUR.DISCORD.TOKEN"
 # Admin権限を持つDiscordロールのID
 ADMIN_ROLE_ID="1234567890"
 
+# 昨年度メンバーロールのID（継続メンバー判定に使用）
+RETURNING_MEMBER_ROLE_ID="1234567890"
+
 # --- GitHub OAuth (SNS連携) ---
 # GitHub Developer Settings > OAuth Apps で取得
 # Callback URL: http://localhost:3000/api/auth/link/github/callback

--- a/app/internal/onboarding/page.tsx
+++ b/app/internal/onboarding/page.tsx
@@ -1,5 +1,6 @@
 import { auth } from "@/lib/auth";
 import { getMember, isOnboardingComplete } from "@/lib/members";
+import { checkReturningMember } from "@/lib/discord";
 import { redirect } from "next/navigation";
 import OnboardingForm from "@/components/onboarding-form";
 
@@ -15,10 +16,18 @@ export default async function OnboardingPage({
   const isDevPreview =
     process.env.NODE_ENV === "development" && params.preview !== undefined;
 
-  const member = await getMember(session.user.id);
+  const [member, isReturningMember] = await Promise.all([
+    getMember(session.user.id),
+    checkReturningMember(session.user.id),
+  ]);
   if (member && isOnboardingComplete(member) && !isDevPreview) {
     redirect("/internal");
   }
 
-  return <OnboardingForm lineBotFriendUrl={process.env.LINE_BOT_FRIEND_URL} />;
+  return (
+    <OnboardingForm
+      lineBotFriendUrl={process.env.LINE_BOT_FRIEND_URL}
+      isReturningMember={isReturningMember}
+    />
+  );
 }

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -20,6 +20,15 @@ import type { SnsEntry } from "@/components/member-tile-preview";
 import type { Area } from "react-easy-crop";
 import type { PublicImageOption } from "@/lib/members";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 import { normalizeLinkedInUrl } from "@/lib/linkedin";
 import type { FormData, VisibilityForm } from "./onboarding/types";
 import { VISIBILITY_DISPLAY_KEYS } from "./onboarding/types";
@@ -46,8 +55,10 @@ import {
 
 export default function OnboardingForm({
   lineBotFriendUrl,
+  isReturningMember,
 }: {
   lineBotFriendUrl?: string;
+  isReturningMember?: boolean;
 }) {
   const { update: updateSession } = useSession();
   const router = useRouter();
@@ -77,6 +88,7 @@ export default function OnboardingForm({
       !searchParams.get("error"),
   );
   const [welcomeFading, setWelcomeFading] = useState(false);
+  const [showFeeNotice, setShowFeeNotice] = useState(false);
   const [currentStep, setCurrentStep] = useState(initialStep);
   const [form, setForm] = useState<FormData>(DEFAULT_FORM);
   const [allowPublic, setAllowPublic] = useState(true);
@@ -1015,8 +1027,11 @@ export default function OnboardingForm({
     setTimeout(() => {
       setShowWelcome(false);
       setWelcomeFading(false);
+      if (isReturningMember) {
+        setShowFeeNotice(true);
+      }
     }, 500);
-  }, []);
+  }, [isReturningMember]);
 
   if (loading) {
     return (
@@ -1201,6 +1216,36 @@ export default function OnboardingForm({
           onbExternalSns={onbExternalSns}
         />
       )}
+
+      {/* 継続メンバー向け会費通知モーダル */}
+      <Dialog open={showFeeNotice} onOpenChange={() => {}}>
+        <DialogContent
+          onInteractOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          className="[&>button:last-child]:hidden"
+        >
+          <DialogHeader>
+            <DialogTitle>継続メンバーの皆さまへ</DialogTitle>
+            <DialogDescription className="text-balance">
+              今年度もLumosでの活動を続けてくださり、ありがとうございます！
+            </DialogDescription>
+          </DialogHeader>
+          <div className="text-sm">
+            <p>
+              年会費は <span className="font-bold">3,000円</span>{" "}
+              です。5月頃に対面で集金します。
+              <br />
+              (詳細は後日アナウンス予定)
+            </p>
+            <p className="mt-2 text-xs text-muted-foreground">
+              ※卒業生の方は対象外です。
+            </p>
+          </div>
+          <DialogFooter className="sm:justify-center">
+            <Button onClick={() => setShowFeeNotice(false)}>確認した</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,7 +20,8 @@ variable "cloud_run_env_vars" {
   type = map(map(string))
   default = {
     dev = {
-      ADMIN_ROLE_ID = "1368939833162076200"
+      ADMIN_ROLE_ID            = "1368939833162076200"
+      RETURNING_MEMBER_ROLE_ID = "1492146121663971409"
 
       AUTH_GITHUB_ID = "Ov23liN6oGK1lfbZm3P2"
       AUTH_X_ID      = "eW5jSnZRbEFBLWJMY1Z3NTFmVXQ6MTpjaQ"
@@ -36,7 +37,8 @@ variable "cloud_run_env_vars" {
       LINE_GROUP_ID         = "C1634d113e1d5a316077098b5776b94b5"
     }
     stg = {
-      ADMIN_ROLE_ID = "1368939833162076200"
+      ADMIN_ROLE_ID            = "1368939833162076200"
+      RETURNING_MEMBER_ROLE_ID = "1492146121663971409"
 
       AUTH_GITHUB_ID = "Ov23li6SPPesKvJDqXiO"
       AUTH_X_ID      = "MktOVXFWdWNFZzN5VzI2TXJFZ2Q6MTpjaQ"
@@ -52,7 +54,8 @@ variable "cloud_run_env_vars" {
       LINE_GROUP_ID         = "C5a28521ffe1f42b16998bd506acab713"
     }
     prd = {
-      ADMIN_ROLE_ID = "1478450042749849670"
+      ADMIN_ROLE_ID            = "1478450042749849670"
+      RETURNING_MEMBER_ROLE_ID = "1356896104351793154"
 
       AUTH_GITHUB_ID = "Ov23liaSCNoELzDDQ71W"
       AUTH_X_ID      = "UUthQmxHVlY1anFBU0VtWmQxUmU6MTpjaQ"

--- a/lib/discord.ts
+++ b/lib/discord.ts
@@ -217,6 +217,38 @@ export async function getEventInterestedUsers(
 }
 
 /**
+ * Check if a Discord user has the returning member role (昨年度メンバー)
+ */
+export async function checkReturningMember(userId: string): Promise<boolean> {
+  const guildId = process.env.DISCORD_GUILD_ID;
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  const returningRoleId = process.env.RETURNING_MEMBER_ROLE_ID;
+
+  if (!guildId || !botToken || !returningRoleId) {
+    return false;
+  }
+
+  try {
+    const response = await fetch(
+      `${DISCORD_API_BASE}/guilds/${guildId}/members/${userId}`,
+      {
+        headers: {
+          Authorization: `Bot ${botToken}`,
+        },
+      },
+    );
+
+    if (!response.ok) return false;
+
+    const member = await response.json();
+    return member.roles?.includes(returningRoleId) ?? false;
+  } catch (e) {
+    console.error("Failed to check returning member role:", e);
+    return false;
+  }
+}
+
+/**
  * Get avatar URL for a Discord user
  */
 export function getDiscordAvatarUrl(


### PR DESCRIPTION
## Summary
- Onboardingフローに継続メンバー（昨年度メンバーロール保持者）向けの年会費通知モーダルを追加
- Onboarding完了時に継続メンバー向け満足度アンケートDialogを追加（Firestore `surveys`コレクションに保存）
- Discord Bot APIでロール判定する `checkReturningMember` 関数を追加（JWTには含めない）
- `RETURNING_MEMBER_ROLE_ID` 環境変数を各環境（dev/stg/prd）に設定

## 動作フロー
```
Welcome画面 → "はじめる" → [継続メンバーのみ] 会費通知Dialog → Step 1
                           [新規メンバー] → 直接 Step 1

... Steps ...

最終Step → 完了ボタン → [継続メンバーのみ] アンケートDialog → complete画面
                         [新規メンバー] → 直接 complete画面
```

## 変更ファイル
- `lib/discord.ts` — `checkReturningMember()` 関数追加
- `.env.example` — `RETURNING_MEMBER_ROLE_ID` 追加
- `app/internal/onboarding/page.tsx` — サーバーサイドでロール判定、propとして渡す
- `components/onboarding-form.tsx` — 会費通知Dialog + アンケートDialog実装
- `app/api/survey/route.ts` — アンケート回答保存API（新規）
- `infra/variables.tf` — 各環境にロールID設定

## Test plan
- [ ] `just dev` でOnboardingフローを通して動作確認
- [ ] 継続メンバー: Welcome後に会費通知モーダルが表示されること
- [ ] 継続メンバー: 完了後にアンケートDialogが表示されること
- [ ] 新規メンバー: 両モーダルが表示されないこと
- [ ] アンケート満足度未選択で送信ボタンがdisabledであること
- [ ] アンケート送信後にcomplete画面に遷移すること
- [ ] モーダルの外側クリック・Escで閉じないこと