### PR TITLE
✨ 継続メンバー向けアンケート + embla-carousel修正

### DIFF
--- a/app/api/survey/route.ts
+++ b/app/api/survey/route.ts
@@ -24,14 +24,14 @@ export async function POST(req: Request) {
   }
 
   const db = getDb();
-  const docId = `${session.user.id}_onboarding_2025`;
+  const docId = `${session.user.id}_onboarding_2026`;
 
   await db
     .collection("surveys")
     .doc(docId)
     .set({
       discordId: session.user.id,
-      type: "onboarding_2025",
+      type: "onboarding_2026",
       satisfaction,
       ...(satisfactionReason ? { satisfactionReason } : {}),
       ...(expectations ? { expectations } : {}),

--- a/app/api/survey/route.ts
+++ b/app/api/survey/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { getDb } from "@/lib/firebase";
+import { FieldValue } from "firebase-admin/firestore";
+
+export async function POST(req: Request) {
+  const session = await auth();
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const body = await req.json();
+  const { satisfaction, satisfactionReason, expectations } = body;
+
+  if (
+    typeof satisfaction !== "number" ||
+    satisfaction < 1 ||
+    satisfaction > 5
+  ) {
+    return NextResponse.json(
+      { error: "satisfaction must be 1-5" },
+      { status: 400 },
+    );
+  }
+
+  const db = getDb();
+  const docId = `${session.user.id}_onboarding_2025`;
+
+  await db
+    .collection("surveys")
+    .doc(docId)
+    .set({
+      discordId: session.user.id,
+      type: "onboarding_2025",
+      satisfaction,
+      ...(satisfactionReason ? { satisfactionReason } : {}),
+      ...(expectations ? { expectations } : {}),
+      createdAt: FieldValue.serverTimestamp(),
+    });
+
+  return NextResponse.json({ success: true });
+}

--- a/app/internal/onboarding/page.tsx
+++ b/app/internal/onboarding/page.tsx
@@ -20,7 +20,8 @@ export default async function OnboardingPage({
     getMember(session.user.id),
     checkReturningMember(session.user.id),
   ]);
-  if (member && isOnboardingComplete(member) && !isDevPreview) {
+  const isSurvey = params.survey === "1";
+  if (member && isOnboardingComplete(member) && !isDevPreview && !isSurvey) {
     redirect("/internal");
   }
 

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -29,6 +29,8 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Star } from "lucide-react";
 import { normalizeLinkedInUrl } from "@/lib/linkedin";
 import type { FormData, VisibilityForm } from "./onboarding/types";
 import { VISIBILITY_DISPLAY_KEYS } from "./onboarding/types";
@@ -89,6 +91,11 @@ export default function OnboardingForm({
   );
   const [welcomeFading, setWelcomeFading] = useState(false);
   const [showFeeNotice, setShowFeeNotice] = useState(false);
+  const [showSurvey, setShowSurvey] = useState(false);
+  const [surveyRating, setSurveyRating] = useState(0);
+  const [surveyReason, setSurveyReason] = useState("");
+  const [surveyExpectations, setSurveyExpectations] = useState("");
+  const [surveySubmitting, setSurveySubmitting] = useState(false);
   const [currentStep, setCurrentStep] = useState(initialStep);
   const [form, setForm] = useState<FormData>(DEFAULT_FORM);
   const [allowPublic, setAllowPublic] = useState(true);
@@ -983,6 +990,10 @@ export default function OnboardingForm({
           /* ignore */
         }
         await updateSession();
+        if (isReturningMember) {
+          setShowSurvey(true);
+          return;
+        }
         router.push("/internal/onboarding/complete");
       } else {
         const data = await res.json();
@@ -1032,6 +1043,30 @@ export default function OnboardingForm({
       }
     }, 500);
   }, [isReturningMember]);
+
+  const handleSurveySubmit = useCallback(async () => {
+    setSurveySubmitting(true);
+    try {
+      await fetch("/api/survey", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          satisfaction: surveyRating,
+          ...(surveyReason.trim()
+            ? { satisfactionReason: surveyReason.trim() }
+            : {}),
+          ...(surveyExpectations.trim()
+            ? { expectations: surveyExpectations.trim() }
+            : {}),
+        }),
+      });
+    } catch {
+      /* non-blocking */
+    } finally {
+      setSurveySubmitting(false);
+    }
+    router.push("/internal/onboarding/complete");
+  }, [surveyRating, surveyReason, surveyExpectations, router]);
 
   if (loading) {
     return (
@@ -1243,6 +1278,76 @@ export default function OnboardingForm({
           </div>
           <DialogFooter className="sm:justify-center">
             <Button onClick={() => setShowFeeNotice(false)}>確認した</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* 継続メンバー向けアンケート */}
+      <Dialog open={showSurvey} onOpenChange={() => {}}>
+        <DialogContent
+          onInteractOutside={(e) => e.preventDefault()}
+          onEscapeKeyDown={(e) => e.preventDefault()}
+          className="[&>button:last-child]:hidden"
+        >
+          <DialogHeader>
+            <DialogTitle>活動についてのアンケート</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-5">
+            <div>
+              <p className="text-sm font-medium">
+                現在のLumosの活動の満足度を教えてください。
+                <span className="text-destructive ml-1">*</span>
+              </p>
+              <div className="flex items-center justify-center gap-3 mt-3">
+                {[1, 2, 3, 4, 5].map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setSurveyRating(n)}
+                    className="flex flex-col items-center gap-1 group"
+                  >
+                    <span className="text-xs text-muted-foreground">{n}</span>
+                    <Star
+                      className={`h-8 w-8 transition-colors ${
+                        n <= surveyRating
+                          ? "fill-yellow-400 text-yellow-400"
+                          : "text-muted-foreground/40 group-hover:text-yellow-300"
+                      }`}
+                    />
+                  </button>
+                ))}
+              </div>
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-2">
+                回答された満足度について、理由があれば教えてください。
+              </p>
+              <Textarea
+                placeholder="回答を入力"
+                value={surveyReason}
+                onChange={(e) => setSurveyReason(e.target.value)}
+                rows={2}
+              />
+            </div>
+            <div>
+              <p className="text-sm font-medium mb-2">
+                これからのLumosに期待することや、やりたい企画があれば教えてください
+              </p>
+              <Textarea
+                placeholder="回答を入力"
+                value={surveyExpectations}
+                onChange={(e) => setSurveyExpectations(e.target.value)}
+                rows={2}
+              />
+            </div>
+          </div>
+          <DialogFooter className="sm:justify-center">
+            <Button
+              onClick={handleSurveySubmit}
+              disabled={surveyRating === 0 || surveySubmitting}
+            >
+              {surveySubmitting ? "送信中..." : "送信する"}
+            </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -87,11 +87,12 @@ export default function OnboardingForm({
   const [showWelcome, setShowWelcome] = useState(
     !searchParams.get("step") &&
       !searchParams.get("success") &&
-      !searchParams.get("error"),
+      !searchParams.get("error") &&
+      !searchParams.get("survey"),
   );
   const [welcomeFading, setWelcomeFading] = useState(false);
   const [showFeeNotice, setShowFeeNotice] = useState(false);
-  const [showSurvey, setShowSurvey] = useState(false);
+  const showSurvey = searchParams.get("survey") === "1";
   const [surveyRating, setSurveyRating] = useState(0);
   const [surveyReason, setSurveyReason] = useState("");
   const [surveyExpectations, setSurveyExpectations] = useState("");
@@ -991,7 +992,7 @@ export default function OnboardingForm({
         }
         await updateSession();
         if (isReturningMember) {
-          setShowSurvey(true);
+          router.replace("?survey=1");
           return;
         }
         router.push("/internal/onboarding/complete");
@@ -1331,7 +1332,7 @@ export default function OnboardingForm({
             </div>
             <div>
               <p className="text-sm font-medium mb-2">
-                これからのLumosに期待することや、やりたい企画があれば教えてください
+                これからのLumosに期待することや、やりたい企画があれば教えてください。
               </p>
               <Textarea
                 placeholder="回答を入力"

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "cmdk": "1.0.4",
     "date-fns": "4.1.0",
     "embla-carousel-autoplay": "^8.6.0",
-    "embla-carousel-react": "8.5.1",
+    "embla-carousel-react": "8.6.0",
     "firebase-admin": "^13.8.0",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -129,8 +129,8 @@ importers:
         specifier: ^8.6.0
         version: 8.6.0(embla-carousel@8.6.0)
       embla-carousel-react:
-        specifier: 8.5.1
-        version: 8.5.1(react@19.2.5)
+        specifier: 8.6.0
+        version: 8.6.0(react@19.2.5)
       firebase-admin:
         specifier: ^13.8.0
         version: 13.8.0
@@ -3062,18 +3062,15 @@ packages:
     peerDependencies:
       embla-carousel: 8.6.0
 
-  embla-carousel-react@8.5.1:
-    resolution: {integrity: sha512-z9Y0K84BJvhChXgqn2CFYbfEi6AwEr+FFVVKm/MqbTQ2zIzO1VQri6w67LcfpVF0AjbhwVMywDZqY4alYkjW5w==}
+  embla-carousel-react@8.6.0:
+    resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  embla-carousel-reactive-utils@8.5.1:
-    resolution: {integrity: sha512-n7VSoGIiiDIc4MfXF3ZRTO59KDp820QDuyBDGlt5/65+lumPHxX2JLz0EZ23hZ4eg4vZGUXwMkYv02fw2JVo/A==}
+  embla-carousel-reactive-utils@8.6.0:
+    resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
     peerDependencies:
-      embla-carousel: 8.5.1
-
-  embla-carousel@8.5.1:
-    resolution: {integrity: sha512-JUb5+FOHobSiWQ2EJNaueCNT/cQU9L6XWBbWmorWPQT9bkbk+fhsuLr8wWrzXKagO3oWszBO7MSx+GfaRk4E6A==}
+      embla-carousel: 8.6.0
 
   embla-carousel@8.6.0:
     resolution: {integrity: sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==}
@@ -9354,17 +9351,15 @@ snapshots:
     dependencies:
       embla-carousel: 8.6.0
 
-  embla-carousel-react@8.5.1(react@19.2.5):
+  embla-carousel-react@8.6.0(react@19.2.5):
     dependencies:
-      embla-carousel: 8.5.1
-      embla-carousel-reactive-utils: 8.5.1(embla-carousel@8.5.1)
+      embla-carousel: 8.6.0
+      embla-carousel-reactive-utils: 8.6.0(embla-carousel@8.6.0)
       react: 19.2.5
 
-  embla-carousel-reactive-utils@8.5.1(embla-carousel@8.5.1):
+  embla-carousel-reactive-utils@8.6.0(embla-carousel@8.6.0):
     dependencies:
-      embla-carousel: 8.5.1
-
-  embla-carousel@8.5.1: {}
+      embla-carousel: 8.6.0
 
   embla-carousel@8.6.0: {}
 


### PR DESCRIPTION
## Summary
- Onboarding完了時に継続メンバー向けの満足度アンケートDialogを追加
- アンケート回答をFirestore `surveys` コレクションに保存するAPIを追加
- embla-carousel-reactのバージョン不整合によるTS型エラーを修正

## 動作フロー
```
最終Step → 完了ボタン → POST /api/onboarding (成功)
  → [継続メンバーのみ] アンケートDialog → POST /api/survey → complete画面
  → [新規メンバー] → 直接 complete画面
```

## アンケート項目
1. 満足度（1-5星評価、必須）
2. 満足度の理由（テキスト、任意）
3. 期待・やりたい企画（テキスト、任意）

## 変更ファイル
- `app/api/survey/route.ts` — アンケート回答保存API（新規）
- `components/onboarding-form.tsx` — アンケートDialog実装
- `package.json` / `pnpm-lock.yaml` — embla-carousel-react 8.5.1 → 8.6.0

## Test plan
- [ ] 継続メンバー: 完了後にアンケートDialogが表示されること
- [ ] 新規メンバー: アンケートが表示されないこと
- [ ] 満足度未選択で送信ボタンがdisabledであること
- [ ] 回答送信後にcomplete画面に遷移すること
- [ ] Firestoreの `surveys` コレクションにドキュメントが作成されること
- [ ] `pnpm exec tsc --noEmit` で型エラーがないこと