### PR TITLE
🔧 卒業生注釈を全メンバーに常時表示する

### DIFF
--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -1275,11 +1275,9 @@ export default function OnboardingForm({
               <br />
               (詳細は後日アナウンス予定)
             </p>
-            {isReturningMember && (
-              <p className="mt-2 text-xs text-muted-foreground">
-                ※卒業生の方は対象外です。
-              </p>
-            )}
+            <p className="mt-2 text-xs text-muted-foreground">
+              ※卒業生の方は対象外です。
+            </p>
           </div>
           <DialogFooter className="sm:justify-center">
             <Button onClick={() => setShowFeeNotice(false)}>確認した</Button>


### PR DESCRIPTION
## Summary
- 会費通知モーダルの「※卒業生の方は対象外です。」を継続メンバー限定から全メンバー共通表示に変更

## Test plan
- [ ] 新規メンバーで会費通知モーダルに卒業生注釈が表示されること
- [ ] 継続メンバーでも引き続き卒業生注釈が表示されること