### PR TITLE
🔧 Firestore データベースを Terraform にインポート

### DIFF
--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -1,0 +1,57 @@
+resource "google_firestore_database" "production" {
+  project                     = var.project_id
+  name                        = "(default)"
+  location_id                 = var.region
+  type                        = "FIRESTORE_NATIVE"
+  deletion_policy             = "PREVENT"
+  delete_protection_state     = "DELETE_PROTECTION_ENABLED"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = all
+  }
+}
+
+resource "google_firestore_database" "development" {
+  project                           = var.project_id
+  name                              = "development"
+  location_id                       = var.region
+  type                              = "FIRESTORE_NATIVE"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  deletion_policy                   = "PREVENT"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = all
+  }
+}
+
+resource "google_firestore_database" "staging" {
+  project                           = var.project_id
+  name                              = "staging"
+  location_id                       = var.region
+  type                              = "FIRESTORE_NATIVE"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  deletion_policy                   = "PREVENT"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = all
+  }
+}
+
+resource "google_firestore_backup_schedule" "staging_daily" {
+  project  = var.project_id
+  database = google_firestore_database.staging.name
+
+  retention = "2592000s" # 30 days
+
+  daily_recurrence {}
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = all
+  }
+}


### PR DESCRIPTION
## 概要
- 既存の Firestore データベース 3 つ (production, development, staging) を Terraform 管理下に追加
- staging の日次バックアップスケジュール (30日保持) もインポート
- development / staging の PITR (7日間) を定義に反映

## 安全性
- 全リソースに `lifecycle { prevent_destroy = true; ignore_changes = all }` を設定済み
- `deletion_policy = "PREVENT"` および `delete_protection_state = "DELETE_PROTECTION_ENABLED"` により削除を防止
- `terraform plan` で **No changes** を確認済み

## テスト計画
- [x] `terraform import` で 3 データベース + 1 バックアップスケジュールをインポート
- [x] `terraform plan` で差分なしを確認