### PR TITLE
🔧 本番 Firestore の PITR 有効化と日次バックアップを追加

### DIFF
--- a/infra/firestore.tf
+++ b/infra/firestore.tf
@@ -1,10 +1,11 @@
 resource "google_firestore_database" "production" {
-  project                     = var.project_id
-  name                        = "(default)"
-  location_id                 = var.region
-  type                        = "FIRESTORE_NATIVE"
-  deletion_policy             = "PREVENT"
-  delete_protection_state     = "DELETE_PROTECTION_ENABLED"
+  project                           = var.project_id
+  name                              = "(default)"
+  location_id                       = var.region
+  type                              = "FIRESTORE_NATIVE"
+  point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
+  deletion_policy                   = "PREVENT"
+  delete_protection_state           = "DELETE_PROTECTION_ENABLED"
 
   lifecycle {
     prevent_destroy = true
@@ -35,6 +36,20 @@ resource "google_firestore_database" "staging" {
   point_in_time_recovery_enablement = "POINT_IN_TIME_RECOVERY_ENABLED"
   deletion_policy                   = "PREVENT"
   delete_protection_state           = "DELETE_PROTECTION_ENABLED"
+
+  lifecycle {
+    prevent_destroy = true
+    ignore_changes  = all
+  }
+}
+
+resource "google_firestore_backup_schedule" "production_daily" {
+  project  = var.project_id
+  database = google_firestore_database.production.name
+
+  retention = "2592000s" # 30 days
+
+  daily_recurrence {}
 
   lifecycle {
     prevent_destroy = true


### PR DESCRIPTION
Closes #191

## 概要
- 本番 (default) Firestore データベースに PITR (7日間保持) を有効化
- 日次バックアップスケジュール (30日保持) を新規作成
- staging と同じバックアップ構成に統一

## 適用済みの変更
- `gcloud firestore databases update --enable-pitr` で PITR を有効化済み
- `terraform apply` でバックアップスケジュールを作成済み
- `terraform plan` で **No changes** を確認済み

## テスト計画
- [x] `terraform plan` で差分なしを確認
- [x] `gcloud firestore backups schedules list` でスケジュール作成を確認