### PR TITLE
mini-ltページのパスの修正

### DIFF
--- a/app/mini-lt/admin/page.tsx
+++ b/app/mini-lt/admin/page.tsx
@@ -60,7 +60,7 @@ export default async function AdminPage({
             <p className="text-muted-foreground mb-4">
               このページにアクセスする権限がありません
             </p>
-            <Link href="/">
+            <Link href="/mini-lt">
               <Button variant="outline">トップページへ戻る</Button>
             </Link>
           </CardContent>
@@ -101,7 +101,7 @@ export default async function AdminPage({
           <div className="bg-white rounded-2xl shadow-xl p-6 mb-8">
             <WeekNavigator
               currentWeek={weekId}
-              baseUrl="/admin"
+              baseUrl="/mini-lt/admin"
               showSendButton
             />
           </div>
@@ -208,7 +208,7 @@ export default async function AdminPage({
           </Card>
 
           <div className="mt-8 text-center">
-            <Link href="/">
+            <Link href="/mini-lt">
               <Button variant="outline">← トップページへ戻る</Button>
             </Link>
           </div>

--- a/app/mini-lt/event/[date]/page.tsx
+++ b/app/mini-lt/event/[date]/page.tsx
@@ -37,7 +37,7 @@ export default async function EventRedirectPage({ params }: PageProps) {
 
   // If no Discord event exists, redirect to home page for that week immediately
   if (!weekData.discordEventUrl) {
-    redirect(`/?week=${weekId}`);
+    redirect(`/mini-lt?week=${weekId}`);
   }
 
   const redirectUrl = weekData.discordEventUrl;

--- a/app/mini-lt/page.tsx
+++ b/app/mini-lt/page.tsx
@@ -93,7 +93,7 @@ export default async function HomePage({
                   💭 雑談ベース
                 </span>
               </div>
-              <Link href="/mini-lt/submit">
+              <Link href={`/mini-lt/submit?week=${weekId}`}>
                 <button className="bg-gradient-to-r from-orange-500 to-yellow-500 text-white px-8 py-3 rounded-xl font-bold hover:shadow-xl transition-all hover:scale-105 flex items-center gap-2 mx-auto">
                   <span className="text-xl">🎤</span>
                   <span>気軽に発表登録してみる</span>
@@ -103,7 +103,7 @@ export default async function HomePage({
           </div>
         </div>
         <div className="bg-white rounded-2xl shadow-md p-2 mb-4">
-          <WeekNavigator currentWeek={weekId} baseUrl="/" />
+          <WeekNavigator currentWeek={weekId} baseUrl="/mini-lt" />
         </div>
 
         {/* Discord Event Call to Action & Interested Users */}
@@ -142,7 +142,7 @@ export default async function HomePage({
         )}
 
         <footer className="mt-12 text-center pb-8">
-          <Link href="/mini-lt/submit">
+          <Link href={`/mini-lt/submit?week=${weekId}`}>
             <Badge
               variant="outline"
               className="cursor-pointer hover:bg-purple-50 hover:border-purple-300 px-5 py-2 transition-all hover:scale-105"
@@ -154,7 +154,7 @@ export default async function HomePage({
       </div>
 
       {/* Floating Action Button */}
-      <Link href="/mini-lt/submit">
+      <Link href={`/mini-lt/submit?week=${weekId}`}>
         <button className="fixed bottom-8 right-8 bg-gradient-to-r from-orange-500 to-yellow-500 text-white px-6 py-4 rounded-full shadow-2xl hover:shadow-3xl transition-all hover:scale-110 z-50 animate-float group flex items-center gap-2 font-bold">
           <span className="text-2xl">➕</span>
           <span className="text-sm">発表登録</span>

--- a/app/mini-lt/submit/page.tsx
+++ b/app/mini-lt/submit/page.tsx
@@ -57,7 +57,7 @@ export default async function SubmitPage({
           </form>
           <div className="mt-8 pt-6 border-t">
             <Link
-              href="/"
+              href="/mini-lt"
               className="text-sm text-muted-foreground hover:text-purple-600 transition-colors"
             >
               ← 公開ページへ戻る
@@ -99,7 +99,7 @@ export default async function SubmitPage({
           </form>
           <div className="mt-8 pt-6 border-t">
             <Link
-              href="/"
+              href="/mini-lt"
               className="text-sm text-muted-foreground hover:text-purple-600 transition-colors"
             >
               ← 公開ページへ戻る
@@ -182,8 +182,8 @@ export default async function SubmitPage({
       }
     }
 
-    revalidatePath("/submit");
-    revalidatePath("/");
+    revalidatePath("/mini-lt/submit");
+    revalidatePath("/mini-lt");
   };
 
   const handleDelete = async (talkId: string) => {
@@ -202,8 +202,8 @@ export default async function SubmitPage({
       }
     }
 
-    revalidatePath("/submit");
-    revalidatePath("/");
+    revalidatePath("/mini-lt/submit");
+    revalidatePath("/mini-lt");
   };
 
   return (
@@ -267,7 +267,7 @@ export default async function SubmitPage({
           />
 
           <div className="mt-12 text-center pb-8">
-            <Link href="/">
+            <Link href="/mini-lt">
               <Button
                 variant="outline"
                 className="hover:bg-purple-50 hover:border-purple-300"

--- a/components/mini-lt/Header.tsx
+++ b/components/mini-lt/Header.tsx
@@ -11,7 +11,7 @@ export async function Header() {
       <div className="absolute inset-0 bg-grid-white/[0.05] bg-[size:20px_20px]"></div>
       <div className="container mx-auto px-4 py-6 max-w-5xl relative">
         <div className="flex items-center justify-between">
-          <Link href="/" className="flex-1">
+          <Link href="/mini-lt" className="flex-1">
             <div className="text-center text-white cursor-pointer hover:opacity-90 transition-opacity">
               {/* Lumos Logo Area */}
               <div className="flex items-center justify-center mb-3">

--- a/lib/mini-lt/actions/discord-events.ts
+++ b/lib/mini-lt/actions/discord-events.ts
@@ -73,8 +73,8 @@ export async function createWeekEvent(weekId: string): Promise<void> {
   const eventUrl = getDiscordEventUrl(event.id);
   await saveDiscordEvent(weekId, event.id, eventUrl);
 
-  revalidatePath("/admin");
-  revalidatePath("/");
+  revalidatePath("/mini-lt/admin");
+  revalidatePath("/mini-lt");
 }
 
 /**
@@ -93,8 +93,8 @@ export async function syncWeekEventDescription(
     description,
   });
 
-  revalidatePath("/admin");
-  revalidatePath("/");
+  revalidatePath("/mini-lt/admin");
+  revalidatePath("/mini-lt");
 }
 
 /**
@@ -107,6 +107,6 @@ export async function deleteWeekEvent(
   await deleteDiscordEvent(eventId);
   await removeDiscordEvent(weekId);
 
-  revalidatePath("/admin");
-  revalidatePath("/");
+  revalidatePath("/mini-lt/admin");
+  revalidatePath("/mini-lt");
 }

--- a/lib/mini-lt/actions/line.ts
+++ b/lib/mini-lt/actions/line.ts
@@ -40,6 +40,6 @@ export async function sendLineNextEvent(): Promise<void> {
     );
   }
 
-  revalidatePath("/admin");
-  revalidatePath("/");
+  revalidatePath("/mini-lt/admin");
+  revalidatePath("/mini-lt");
 }


### PR DESCRIPTION
-基本的にmini-ltページのルートが「/」のままになっていたので、「/mini-lt」にした
-次回または前回の内容を表示した状態からの発表登録は、その回に対しての登録になるように、週のクエリパラメータを付けるようにした