### PR TITLE
✨ 管理者向け開発者ツールページと NEXT_PUBLIC_APP_ENV の導入

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,7 @@
+# --- アプリケーション環境 ---
+# local / development / staging / production
+NEXT_PUBLIC_APP_ENV="local"
+
 # --- Auth.js (NextAuth.js v5) ---
 # `npx auth secret` または `openssl rand -hex 32` で生成 (32バイト / hex 64文字)
 # Cloud Run では Secret Manager から注入されるため設定不要

--- a/.github/workflows/deploy-cloudrun-dev.yaml
+++ b/.github/workflows/deploy-cloudrun-dev.yaml
@@ -49,6 +49,8 @@ jobs:
           tags: asia-northeast1-docker.pkg.dev/lumos-infra/lumos-web/dev:latest
           context: .
           file: ./cloudrun/Dockerfile
+          build-args: |
+            NEXT_PUBLIC_APP_ENV=development
 
       - name: Download Cloud Run Service YAML
         run: |

--- a/.github/workflows/deploy-cloudrun-pr.yaml
+++ b/.github/workflows/deploy-cloudrun-pr.yaml
@@ -44,6 +44,8 @@ jobs:
           tags: asia-northeast1-docker.pkg.dev/lumos-infra/lumos-web/pr-${{ github.event.number }}:latest
           context: .
           file: ./cloudrun/Dockerfile
+          build-args: |
+            NEXT_PUBLIC_APP_ENV=development
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2

--- a/.github/workflows/deploy-cloudrun-release.yaml
+++ b/.github/workflows/deploy-cloudrun-release.yaml
@@ -44,6 +44,8 @@ jobs:
           tags: asia-northeast1-docker.pkg.dev/lumos-infra/lumos-web/prd:latest
           context: .
           file: ./cloudrun/Dockerfile
+          build-args: |
+            NEXT_PUBLIC_APP_ENV=production
 
       - name: Download Cloud Run Service YAML
         run: |

--- a/.github/workflows/deploy-cloudrun-stg.yaml
+++ b/.github/workflows/deploy-cloudrun-stg.yaml
@@ -49,6 +49,8 @@ jobs:
           tags: asia-northeast1-docker.pkg.dev/lumos-infra/lumos-web/stg:latest
           context: .
           file: ./cloudrun/Dockerfile
+          build-args: |
+            NEXT_PUBLIC_APP_ENV=staging
 
       - name: Download Cloud Run Service YAML
         run: |

--- a/app/internal/(protected)/admin/dev-tools/page.tsx
+++ b/app/internal/(protected)/admin/dev-tools/page.tsx
@@ -1,0 +1,70 @@
+import { auth, isAdmin } from "@/lib/auth";
+import { isProduction } from "@/lib/env";
+import { getGuildMemberList } from "@/lib/admin/dev-tools-actions";
+import { DevToolsPanel } from "@/components/admin/dev-tools-panel";
+import { ShieldAlert, Wrench, AlertCircle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+export const dynamic = "force-dynamic";
+
+export default async function DevToolsPage() {
+  if (isProduction()) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <ShieldAlert className="h-16 w-16 text-destructive" />
+        <h1 className="text-2xl font-bold">アクセス拒否</h1>
+        <p className="text-muted-foreground">
+          本番環境ではこのページは使用できません。
+        </p>
+      </div>
+    );
+  }
+
+  const admin = await isAdmin();
+  if (!admin) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <ShieldAlert className="h-16 w-16 text-destructive" />
+        <h1 className="text-2xl font-bold">アクセス拒否</h1>
+        <p className="text-muted-foreground">
+          このページは管理者のみアクセスできます。
+        </p>
+      </div>
+    );
+  }
+
+  const session = await auth();
+  const myDiscordId = session?.user?.id ?? "";
+  const myName = session?.user?.name ?? "自分";
+
+  let members;
+  let error: string | null = null;
+  try {
+    members = await getGuildMemberList();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="container max-w-3xl py-8 px-4">
+      <div className="flex items-center gap-3 mb-6">
+        <Wrench className="h-6 w-6" />
+        <h1 className="text-2xl font-bold">開発者ツール</h1>
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>メンバー一覧の取得に失敗しました</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : (
+        <DevToolsPanel
+          members={members!}
+          myDiscordId={myDiscordId}
+          myName={myName}
+        />
+      )}
+    </div>
+  );
+}

--- a/app/internal/(protected)/admin/dev-tools/page.tsx
+++ b/app/internal/(protected)/admin/dev-tools/page.tsx
@@ -1,4 +1,4 @@
-import { auth, isAdmin } from "@/lib/auth";
+import { auth } from "@/lib/auth";
 import { isProduction } from "@/lib/env";
 import { getGuildMemberList } from "@/lib/admin/dev-tools-actions";
 import { DevToolsPanel } from "@/components/admin/dev-tools-panel";
@@ -15,19 +15,6 @@ export default async function DevToolsPage() {
         <h1 className="text-2xl font-bold">アクセス拒否</h1>
         <p className="text-muted-foreground">
           本番環境ではこのページは使用できません。
-        </p>
-      </div>
-    );
-  }
-
-  const admin = await isAdmin();
-  if (!admin) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <ShieldAlert className="h-16 w-16 text-destructive" />
-        <h1 className="text-2xl font-bold">アクセス拒否</h1>
-        <p className="text-muted-foreground">
-          このページは管理者のみアクセスできます。
         </p>
       </div>
     );

--- a/app/internal/(protected)/admin/layout.tsx
+++ b/app/internal/(protected)/admin/layout.tsx
@@ -1,0 +1,24 @@
+import { isAdmin } from "@/lib/auth";
+import { ShieldAlert } from "lucide-react";
+
+export default async function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const admin = await isAdmin();
+
+  if (!admin) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
+        <ShieldAlert className="h-16 w-16 text-destructive" />
+        <h1 className="text-2xl font-bold">アクセス拒否</h1>
+        <p className="text-muted-foreground">
+          このページは管理者のみアクセスできます。
+        </p>
+      </div>
+    );
+  }
+
+  return <>{children}</>;
+}

--- a/app/internal/(protected)/admin/page.tsx
+++ b/app/internal/(protected)/admin/page.tsx
@@ -1,26 +1,11 @@
-import { isAdmin } from "@/lib/auth";
 import { getUnregisteredMembers } from "@/lib/admin/actions";
 import { AdminNotificationPanel } from "@/components/admin/notification-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Shield, ShieldAlert, AlertCircle } from "lucide-react";
+import { Shield, AlertCircle } from "lucide-react";
 
 export const dynamic = "force-dynamic";
 
 export default async function AdminPage() {
-  const admin = await isAdmin();
-
-  if (!admin) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] gap-4">
-        <ShieldAlert className="h-16 w-16 text-destructive" />
-        <h1 className="text-2xl font-bold">アクセス拒否</h1>
-        <p className="text-muted-foreground">
-          このページは管理者のみアクセスできます。
-        </p>
-      </div>
-    );
-  }
-
   let members;
   let error: string | null = null;
   try {

--- a/cloudrun/Dockerfile
+++ b/cloudrun/Dockerfile
@@ -18,6 +18,10 @@ WORKDIR /app
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 
+# App environment (baked into client bundle via NEXT_PUBLIC_ prefix)
+ARG NEXT_PUBLIC_APP_ENV=development
+ENV NEXT_PUBLIC_APP_ENV=$NEXT_PUBLIC_APP_ENV
+
 # Generate version.json before build
 ARG COMMIT_SHA
 ARG BUILD_DATE

--- a/components/admin/dev-tools-panel.tsx
+++ b/components/admin/dev-tools-panel.tsx
@@ -1,0 +1,386 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import {
+  type GuildMemberInfo,
+  sendTestDiscordMessage,
+  sendTestLineMessage,
+} from "@/lib/admin/dev-tools-actions";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  Select,
+  SelectContent,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import * as SelectPrimitive from "@radix-ui/react-select";
+import { Check } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import {
+  Send,
+  CheckCircle,
+  AlertCircle,
+  Loader2,
+  MessageSquare,
+} from "lucide-react";
+
+const MESSAGE_TYPES = [
+  {
+    value: "welcome",
+    label: "ようこそメッセージ",
+    description: "初回ログイン時に送信。オンボーディングへの誘導ボタン付き。",
+  },
+  {
+    value: "onboarding_complete",
+    label: "オンボーディング完了",
+    description:
+      "オンボーディング完了時に送信。プロフィール充足率とモック未入力項目を表示。",
+  },
+  {
+    value: "login",
+    label: "ログイン通知",
+    description: "通常ログイン時に送信。ランダムな挨拶メッセージが選ばれる。",
+  },
+  {
+    value: "welcome_back",
+    label: "おかえりメッセージ",
+    description:
+      "7日以上ぶりのログイン時に送信。プロフィール充足率とモック未入力項目を表示。",
+  },
+  {
+    value: "registration_nudge",
+    label: "登録案内",
+    description: "Lumos Web未登録のDiscordメンバーに送信。メンバー登録を促す。",
+  },
+  {
+    value: "onboarding_nudge",
+    label: "オンボーディング案内",
+    description:
+      "ログイン済みだがオンボーディング未完了のメンバーに送信。完了を促す。",
+  },
+] as const;
+
+interface DevToolsPanelProps {
+  members: GuildMemberInfo[];
+  myDiscordId: string;
+  myName: string;
+}
+
+export function DevToolsPanel({
+  members,
+  myDiscordId,
+  myName,
+}: DevToolsPanelProps) {
+  return (
+    <Tabs defaultValue="discord">
+      <TabsList className="mb-4">
+        <TabsTrigger value="discord">Discord メッセージ</TabsTrigger>
+        <TabsTrigger value="line">LINE メッセージ</TabsTrigger>
+      </TabsList>
+      <TabsContent value="discord">
+        <DiscordTab
+          members={members}
+          myDiscordId={myDiscordId}
+          myName={myName}
+        />
+      </TabsContent>
+      <TabsContent value="line">
+        <LineTab />
+      </TabsContent>
+    </Tabs>
+  );
+}
+
+// --- Discord Tab ---
+
+function DiscordTab({
+  members,
+  myDiscordId,
+  myName,
+}: {
+  members: GuildMemberInfo[];
+  myDiscordId: string;
+  myName: string;
+}) {
+  const [messageType, setMessageType] = useState<string>("welcome");
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [result, setResult] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const allSelected = members.length > 0 && selected.size === members.length;
+
+  function toggleAll() {
+    if (allSelected) {
+      setSelected(new Set());
+    } else {
+      setSelected(new Set(members.map((m) => m.discordId)));
+    }
+  }
+
+  function toggleMember(discordId: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(discordId)) {
+        next.delete(discordId);
+      } else {
+        next.add(discordId);
+      }
+      return next;
+    });
+  }
+
+  function handleSendToSelf() {
+    if (!messageType) return;
+    setResult(null);
+    startTransition(async () => {
+      const res = await sendTestDiscordMessage(messageType, myDiscordId);
+      setResult(
+        res.success
+          ? { type: "success", message: `${myName} に送信しました` }
+          : { type: "error", message: res.error ?? "送信に失敗しました" },
+      );
+    });
+  }
+
+  function handleSendToSelected() {
+    if (!messageType || selected.size === 0) return;
+    setResult(null);
+    startTransition(async () => {
+      const ids = Array.from(selected);
+      let successCount = 0;
+      let lastError: string | undefined;
+
+      for (const id of ids) {
+        const res = await sendTestDiscordMessage(messageType, id);
+        if (res.success) {
+          successCount++;
+        } else {
+          lastError = res.error;
+        }
+      }
+
+      const failCount = ids.length - successCount;
+      if (failCount === 0) {
+        setResult({
+          type: "success",
+          message: `${successCount}件すべて送信しました`,
+        });
+      } else {
+        setResult({
+          type: "error",
+          message: `${ids.length}件中${successCount}件成功、${failCount}件失敗${lastError ? `: ${lastError}` : ""}`,
+        });
+      }
+      setSelected(new Set());
+    });
+  }
+
+  const selectedType = MESSAGE_TYPES.find((t) => t.value === messageType);
+  const selectedLabel = selectedType?.label ?? "";
+
+  return (
+    <div className="space-y-4">
+      {result && (
+        <Alert variant={result.type === "error" ? "destructive" : "default"}>
+          {result.type === "error" ? (
+            <AlertCircle className="h-4 w-4" />
+          ) : (
+            <CheckCircle className="h-4 w-4" />
+          )}
+          <AlertTitle>
+            {result.type === "success" ? "送信完了" : "エラー"}
+          </AlertTitle>
+          <AlertDescription>{result.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">メッセージタイプ</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Select value={messageType} onValueChange={setMessageType}>
+            <SelectTrigger>
+              <SelectValue placeholder="メッセージタイプを選択" />
+            </SelectTrigger>
+            <SelectContent>
+              {MESSAGE_TYPES.map((type) => (
+                <SelectPrimitive.Item
+                  key={type.value}
+                  value={type.value}
+                  className="relative flex w-full cursor-default select-none items-start rounded-sm py-2 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50"
+                >
+                  <span className="absolute left-2 top-2.5 flex h-3.5 w-3.5 items-center justify-center">
+                    <SelectPrimitive.ItemIndicator>
+                      <Check className="h-4 w-4" />
+                    </SelectPrimitive.ItemIndicator>
+                  </span>
+                  <div>
+                    <SelectPrimitive.ItemText>
+                      {type.label}
+                    </SelectPrimitive.ItemText>
+                    <div className="text-xs text-muted-foreground font-normal mt-0.5">
+                      {type.description}
+                    </div>
+                  </div>
+                </SelectPrimitive.Item>
+              ))}
+            </SelectContent>
+          </Select>
+
+          <Button
+            onClick={handleSendToSelf}
+            disabled={!messageType || isPending}
+            className="w-full"
+          >
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
+            {isPending ? "送信中..." : `自分に送信（${selectedLabel}）`}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-lg">
+              メンバー選択送信
+              <Badge variant="secondary" className="ml-2">
+                {members.length}人
+              </Badge>
+            </CardTitle>
+            <Button
+              onClick={handleSendToSelected}
+              disabled={selected.size === 0 || !messageType || isPending}
+              size="sm"
+            >
+              {isPending ? (
+                <Loader2 className="h-4 w-4 animate-spin" />
+              ) : (
+                <Send className="h-4 w-4" />
+              )}
+              {isPending ? "送信中..." : `送信（${selected.size}件）`}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center gap-3 pb-3 mb-3 border-b">
+            <Checkbox
+              id="select-all-discord"
+              checked={allSelected}
+              onCheckedChange={toggleAll}
+              disabled={isPending}
+            />
+            <label
+              htmlFor="select-all-discord"
+              className="text-sm font-medium cursor-pointer select-none"
+            >
+              全選択
+            </label>
+          </div>
+
+          <div className="space-y-2 max-h-[60vh] overflow-y-auto">
+            {members.map((member) => (
+              <label
+                key={member.discordId}
+                className="flex items-center gap-3 p-2 rounded-md hover:bg-muted/50 cursor-pointer transition-colors"
+              >
+                <Checkbox
+                  checked={selected.has(member.discordId)}
+                  onCheckedChange={() => toggleMember(member.discordId)}
+                  disabled={isPending}
+                />
+                <Avatar className="h-8 w-8">
+                  <AvatarImage
+                    src={member.avatarUrl ?? undefined}
+                    alt={member.displayName}
+                  />
+                  <AvatarFallback className="text-xs">
+                    {member.displayName.charAt(0)}
+                  </AvatarFallback>
+                </Avatar>
+                <p className="text-sm font-medium truncate">
+                  {member.displayName}
+                </p>
+              </label>
+            ))}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+// --- LINE Tab ---
+
+function LineTab() {
+  const [result, setResult] = useState<{
+    type: "success" | "error";
+    message: string;
+  } | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  function handleSend() {
+    setResult(null);
+    startTransition(async () => {
+      const res = await sendTestLineMessage();
+      setResult(
+        res.success
+          ? { type: "success", message: "LINE メッセージを送信しました" }
+          : { type: "error", message: res.error ?? "送信に失敗しました" },
+      );
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {result && (
+        <Alert variant={result.type === "error" ? "destructive" : "default"}>
+          {result.type === "error" ? (
+            <AlertCircle className="h-4 w-4" />
+          ) : (
+            <CheckCircle className="h-4 w-4" />
+          )}
+          <AlertTitle>
+            {result.type === "success" ? "送信完了" : "エラー"}
+          </AlertTitle>
+          <AlertDescription>{result.message}</AlertDescription>
+        </Alert>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-lg">LINE テスト送信</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            環境変数{" "}
+            <code className="text-xs bg-muted px-1 py-0.5 rounded">
+              LINE_PUSH_TARGET_ID
+            </code>{" "}
+            に設定されたターゲットに、次回ミニLTイベントのメッセージを送信します。
+          </p>
+          <Button onClick={handleSend} disabled={isPending} className="w-full">
+            {isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <MessageSquare className="h-4 w-4" />
+            )}
+            {isPending ? "送信中..." : "テスト送信"}
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/app-sidebar.tsx
+++ b/components/app-sidebar.tsx
@@ -11,7 +11,9 @@ import {
   ExternalLink,
   LogOut,
   Shield,
+  Wrench,
 } from "lucide-react";
+import { isProduction } from "@/lib/env";
 import { signOut } from "next-auth/react";
 import {
   Sidebar,
@@ -38,7 +40,17 @@ const NAV_ITEMS = [
 ];
 
 const ADMIN_NAV_ITEMS = [
-  { href: "/internal/admin", icon: Shield, label: "管理者ページ" },
+  { href: "/internal/admin", icon: Shield, label: "管理者ページ", exact: true },
+  ...(!isProduction()
+    ? [
+        {
+          href: "/internal/admin/dev-tools",
+          icon: Wrench,
+          label: "開発者ツール",
+          exact: false,
+        },
+      ]
+    : []),
 ];
 
 interface AppSidebarProps {
@@ -118,7 +130,11 @@ export function AppSidebar({
           <SidebarGroupContent>
             <SidebarMenu>
               {ADMIN_NAV_ITEMS.map((item) => {
-                const isActive = isAdmin && pathname.startsWith(item.href);
+                const isActive = isAdmin
+                  ? item.exact
+                    ? pathname === item.href
+                    : pathname.startsWith(item.href)
+                  : false;
                 return (
                   <SidebarMenuItem key={item.href}>
                     {isAdmin ? (

--- a/infra/variables.tf
+++ b/infra/variables.tf
@@ -20,6 +20,7 @@ variable "cloud_run_env_vars" {
   type = map(map(string))
   default = {
     dev = {
+      NEXT_PUBLIC_APP_ENV      = "development"
       ADMIN_ROLE_ID            = "1368939833162076200"
       RETURNING_MEMBER_ROLE_ID = "1492146121663971409"
 
@@ -37,6 +38,7 @@ variable "cloud_run_env_vars" {
       LINE_GROUP_ID         = "C1634d113e1d5a316077098b5776b94b5"
     }
     stg = {
+      NEXT_PUBLIC_APP_ENV      = "staging"
       ADMIN_ROLE_ID            = "1368939833162076200"
       RETURNING_MEMBER_ROLE_ID = "1492146121663971409"
 
@@ -54,6 +56,7 @@ variable "cloud_run_env_vars" {
       LINE_GROUP_ID         = "C5a28521ffe1f42b16998bd506acab713"
     }
     prd = {
+      NEXT_PUBLIC_APP_ENV      = "production"
       ADMIN_ROLE_ID            = "1478450042749849670"
       RETURNING_MEMBER_ROLE_ID = "1356896104351793154"
 

--- a/lib/admin/dev-tools-actions.ts
+++ b/lib/admin/dev-tools-actions.ts
@@ -1,0 +1,136 @@
+"use server";
+
+import { isAdmin } from "@/lib/auth";
+import { isProduction } from "@/lib/env";
+import { getGuildMembers, type DiscordGuildMember } from "@/lib/discord-guild";
+import {
+  sendDiscordDm,
+  buildWelcomeMessage,
+  buildOnboardingCompleteMessage,
+  buildLoginMessage,
+  buildWelcomeBackMessage,
+  buildRegistrationNudgeMessage,
+  buildOnboardingNudgeMessage,
+  type DiscordMessagePayload,
+} from "@/lib/discord-dm";
+import { sendLineNextEvent } from "@/lib/mini-lt/actions/line";
+
+// --- Types ---
+
+export type GuildMemberInfo = {
+  discordId: string;
+  displayName: string;
+  avatarUrl: string | null;
+};
+
+// --- Helpers ---
+
+function buildAvatarUrl(member: DiscordGuildMember): string | null {
+  const { id, avatar } = member.user;
+  if (!avatar) return null;
+  const extension = avatar.startsWith("a_") ? "gif" : "png";
+  return `https://cdn.discordapp.com/avatars/${id}/${avatar}.${extension}?size=128`;
+}
+
+function buildMessagePayload(
+  messageType: string,
+  displayName: string,
+  discordId: string,
+): DiscordMessagePayload {
+  switch (messageType) {
+    case "welcome":
+      return buildWelcomeMessage(displayName);
+    case "onboarding_complete":
+      return buildOnboardingCompleteMessage(displayName, {
+        percentage: 56,
+        filledCount: 5,
+        totalCount: 9,
+        missingFields: ["GitHub", "LinkedIn", "生年月日", "性別"],
+      });
+    case "login":
+      return buildLoginMessage(displayName);
+    case "welcome_back":
+      return buildWelcomeBackMessage(displayName, discordId, {
+        percentage: 56,
+        filledCount: 5,
+        totalCount: 9,
+        missingFields: ["GitHub", "LinkedIn", "生年月日", "性別"],
+      });
+    case "registration_nudge":
+      return buildRegistrationNudgeMessage(displayName);
+    case "onboarding_nudge":
+      return buildOnboardingNudgeMessage(displayName);
+    default:
+      throw new Error(`不明なメッセージタイプ: ${messageType}`);
+  }
+}
+
+// --- Actions ---
+
+export async function getGuildMemberList(): Promise<GuildMemberInfo[]> {
+  if (!(await isAdmin())) {
+    throw new Error("管理者権限が必要です");
+  }
+  if (isProduction()) {
+    throw new Error("本番環境では使用できません");
+  }
+
+  const members = await getGuildMembers();
+
+  return members
+    .map((m) => ({
+      discordId: m.user.id,
+      displayName: m.nick || m.user.global_name || m.user.username,
+      avatarUrl: buildAvatarUrl(m),
+    }))
+    .sort((a, b) => a.displayName.localeCompare(b.displayName));
+}
+
+export async function sendTestDiscordMessage(
+  messageType: string,
+  targetDiscordId: string,
+): Promise<{ success: boolean; error?: string }> {
+  if (!(await isAdmin())) {
+    return { success: false, error: "管理者権限が必要です" };
+  }
+  if (isProduction()) {
+    return { success: false, error: "本番環境では使用できません" };
+  }
+
+  try {
+    const payload = buildMessagePayload(
+      messageType,
+      "テストユーザー",
+      targetDiscordId,
+    );
+    await sendDiscordDm(targetDiscordId, payload);
+    return { success: true };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}
+
+export async function sendTestLineMessage(): Promise<{
+  success: boolean;
+  error?: string;
+}> {
+  if (!(await isAdmin())) {
+    return { success: false, error: "管理者権限が必要です" };
+  }
+  if (isProduction()) {
+    return { success: false, error: "本番環境では使用できません" };
+  }
+
+  try {
+    await sendLineNextEvent();
+    return { success: true };
+  } catch (e) {
+    return {
+      success: false,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
+}

--- a/lib/discord-dm.ts
+++ b/lib/discord-dm.ts
@@ -36,7 +36,7 @@ type DiscordActionRow = {
   components: DiscordButtonComponent[];
 };
 
-type DiscordMessagePayload = {
+export type DiscordMessagePayload = {
   embeds: DiscordEmbed[];
   components?: DiscordActionRow[];
 };
@@ -336,14 +336,14 @@ export function buildRegistrationNudgeMessage(
           "",
           "2026年度より、Lumosのメンバー管理は **Lumos Web** で行われることになりました。",
           "",
-          "**Lumos Webでできること：**",
+          "### Lumos Webでできること",
           "💬 Lumos2026のLINEグループに参加する",
           "👥 Lumosのメンバーについて知る",
           "🎨 自分だけのプロフィールを作る",
           "📅 ミニLTなどの各種イベントに参加登録する",
           "",
-          "現役生・卒業生・社会人を問わず、",
-          "**2026年度もLumosのDiscordサーバーに参加するためにはLumos Webへの登録が必要です。**",
+          "### ⚠️ 登録が必要です",
+          "現役生・卒業生・社会人を問わず、2026年度もLumosのDiscordサーバーに参加するためには **Lumos Webへの登録が必要** です。",
           "",
           "Discordアカウントで簡単にログインできます。ぜひ登録をお願いします！🙏",
           "",
@@ -352,6 +352,12 @@ export function buildRegistrationNudgeMessage(
         color: WELCOME_COLOR,
         thumbnail: { url: LOGO_URL },
         footer: { text: FOOTER_TEXT },
+      },
+      {
+        title: "🚨 対応期限：2026年4月18日（金）",
+        description:
+          "期限を過ぎるとDiscordサーバーへのアクセスが制限される場合があります。\nお早めの登録をお願いします！",
+        color: 0xed4245, // Discord Red
       },
     ],
     components: [
@@ -384,10 +390,11 @@ export function buildOnboardingNudgeMessage(
           "Lumos Webへのログインありがとうございます！",
           "**オンボーディングがまだ完了していない**ようです。",
           "",
+          "### ⚠️ オンボーディングの完了が必要です",
           "2026年度より、Lumosのメンバー管理はLumos Webで行われます。",
-          "**2026年度もLumosのDiscordサーバーに参加し続けるには、オンボーディングの完了が必要です。**",
+          "2026年度もLumosのDiscordサーバーに参加し続けるには、 **オンボーディングの完了が必要** です。",
           "",
-          "オンボーディングを完了すると、以下の機能も使えるようになります：",
+          "### Lumos Webでできること",
           "👥 Lumosのメンバーについて知る",
           "🎨 自分だけのプロフィールを作る",
           "📅 ミニLTなどの各種イベントに参加登録する",
@@ -400,6 +407,12 @@ export function buildOnboardingNudgeMessage(
         color: WELCOME_COLOR,
         thumbnail: { url: LOGO_URL },
         footer: { text: FOOTER_TEXT },
+      },
+      {
+        title: "🚨 対応期限：2026年4月18日（金）",
+        description:
+          "期限を過ぎるとDiscordサーバーへのアクセスが制限される場合があります。\nお早めの対応をお願いします！",
+        color: 0xed4245, // Discord Red
       },
     ],
     components: [

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,9 @@
+export type AppEnv = "local" | "development" | "staging" | "production";
+
+export function getAppEnv(): AppEnv {
+  return (process.env.NEXT_PUBLIC_APP_ENV as AppEnv) || "local";
+}
+
+export function isProduction(): boolean {
+  return getAppEnv() === "production";
+}


### PR DESCRIPTION
## Summary
- 環境変数 `NEXT_PUBLIC_APP_ENV` を導入し、`lib/env.ts` で `getAppEnv()` / `isProduction()` を提供
  - Terraform (`variables.tf`)、Dockerfile、GitHub Actions 全ワークフローに追加
- 管理者セクションに「開発者ツール」ページを追加（`/internal/admin/dev-tools`）
  - Discord DM: 6種類のメッセージタイプを選択して自分 or メンバーにテスト送信
  - LINE: `LINE_PUSH_TARGET_ID` への次回ミニLTメッセージのテスト送信
  - 本番環境ではサイドバー非表示・ページアクセス拒否
- Discord 登録案内・オンボーディング案内メッセージの改善
  - Markdown 見出し（`###`）でセクション分け
  - 対応期限（4/18）を赤い Embed で目立つ形に追加

## Test plan
- [ ] `just dev` でローカル起動 → サイドバー「管理」に「開発者ツール」が表示されること
- [ ] `/internal/admin/dev-tools` にアクセス → Discord/LINE の各タブが動作すること
- [ ] Discord メッセージタイプを選択し「自分に送信」→ 自分の DM に届くこと
- [ ] メンバー一覧から選択して送信 → 指定メンバーの DM に届くこと
- [ ] LINE テスト送信 → `LINE_PUSH_TARGET_ID` に送信されること
- [ ] `NEXT_PUBLIC_APP_ENV=production` で起動 → サイドバーに非表示、URL 直接アクセスでもアクセス拒否
- [ ] サイドバーで管理者ページと開発者ツールのアクティブ状態が排他的であること
- [ ] `just lint` / `just format-check` が通ること