### PR TITLE
✨ 卒業生のLINE登録を任意化し、グループ参加フローを除去

### DIFF
--- a/app/api/auth/link/line/callback/route.ts
+++ b/app/api/auth/link/line/callback/route.ts
@@ -74,10 +74,14 @@ export async function GET(request: NextRequest) {
       return checkLineBotFriendship(tokenResponse.access_token);
     };
 
-    /** グループ未参加時の not_friend パラメータを付与 */
+    /** グループ未参加時の not_friend パラメータを付与（ベストエフォート） */
     const appendNotFriendParam = async (url: URL) => {
-      if (!(await resolveIsFriend())) {
-        url.searchParams.set("not_friend", "1");
+      try {
+        if (!(await resolveIsFriend())) {
+          url.searchParams.set("not_friend", "1");
+        }
+      } catch {
+        // 友だち判定失敗時はパラメータ無しで続行
       }
     };
 

--- a/app/api/auth/link/line/callback/route.ts
+++ b/app/api/auth/link/line/callback/route.ts
@@ -5,7 +5,7 @@ import {
   fetchProviderUser,
   getCallbackUrl,
 } from "@/lib/oauth-link";
-import { updateMemberSns } from "@/lib/members";
+import { getMember, updateMemberSns } from "@/lib/members";
 import {
   checkLineGroupMembership,
   checkLineBotFriendship,
@@ -44,40 +44,57 @@ export async function GET(request: NextRequest) {
     );
     const user = await fetchProviderUser("line", tokenResponse.access_token);
 
-    // Bot友だち状態を判定
-    // friendship_status_changed=true → 今回追加した（友だち）
-    // friendship_status_changed=false → 追加しなかった（未友だち or ブロック中）
-    // null → 同意画面スキップ → APIで確認
-    let isFriend: boolean;
-    if (friendshipChanged === "true") {
-      isFriend = true;
-    } else if (friendshipChanged === "false") {
-      isFriend = false;
-    } else {
-      isFriend = await checkLineBotFriendship(tokenResponse.access_token);
-    }
-    console.log("LINE friendship status:", isFriend ? "friend" : "not friend");
-
     const isOnboarding = redirectTo.includes("/internal/onboarding");
     const isSettings = redirectTo.includes("/internal/settings");
+    const member = await getMember(discordId);
+    const isAlumni = member?.memberType === "卒業生";
 
+    /** LINE SNS データ（全フローで共通） */
+    const snsData = {
+      line: user.username,
+      lineId: user.id,
+      lineAvatar: user.avatar,
+      lineLinkedAt: Math.floor(Date.now() / 1000),
+      lineAccessToken: tokenResponse.access_token,
+      lineRefreshToken: tokenResponse.refresh_token,
+      lineTokenExpiresAt: tokenResponse.expires_in
+        ? Math.floor(Date.now() / 1000) + tokenResponse.expires_in
+        : undefined,
+    };
+
+    /**
+     * Bot友だち状態を遅延判定（グループ招待が必要な非卒業生フローでのみ使用）
+     * friendship_status_changed=true → 今回追加した（友だち）
+     * friendship_status_changed=false → 追加しなかった（未友だち or ブロック中）
+     * null → 同意画面スキップ → APIで確認
+     */
+    const resolveIsFriend = async () => {
+      if (friendshipChanged === "true") return true;
+      if (friendshipChanged === "false") return false;
+      return checkLineBotFriendship(tokenResponse.access_token);
+    };
+
+    /** グループ未参加時の not_friend パラメータを付与 */
+    const appendNotFriendParam = async (url: URL) => {
+      if (!(await resolveIsFriend())) {
+        url.searchParams.set("not_friend", "1");
+      }
+    };
+
+    // ── 設定画面からの再連携フロー ──
     if (isSettings) {
-      // 再連携フロー: DB更新せず、招待コードに仮情報を保存
+      // 卒業生はグループ参加不要 → 即座にDB更新
+      if (isAlumni) {
+        await updateMemberSns(discordId, snsData);
+        const successUrl = new URL(redirectTo, origin);
+        successUrl.searchParams.set("success", "line_relinked");
+        return NextResponse.redirect(successUrl.toString());
+      }
+
+      // 再連携フロー: グループ参加済みなら即DB更新
       const inGroup = await checkLineGroupMembership(user.id);
       if (inGroup) {
-        // 新アカウントが既にグループ参加済み → 即座にDB更新
-        await updateMemberSns(discordId, {
-          line: user.username,
-          lineId: user.id,
-          lineAvatar: user.avatar,
-          lineLinkedAt: Math.floor(Date.now() / 1000),
-          lineAccessToken: tokenResponse.access_token,
-          lineRefreshToken: tokenResponse.refresh_token,
-          lineTokenExpiresAt: tokenResponse.expires_in
-            ? Math.floor(Date.now() / 1000) + tokenResponse.expires_in
-            : undefined,
-        });
-
+        await updateMemberSns(discordId, snsData);
         const successUrl = new URL(redirectTo, origin);
         successUrl.searchParams.set("success", "line_relinked");
         return NextResponse.redirect(successUrl.toString());
@@ -98,37 +115,23 @@ export async function GET(request: NextRequest) {
       const successUrl = new URL(redirectTo, origin);
       successUrl.searchParams.set("success", "line_linked");
       successUrl.searchParams.set("line_group", "not_joined");
-      if (!isFriend) {
-        successUrl.searchParams.set("not_friend", "1");
-      }
+      await appendNotFriendParam(successUrl);
       return NextResponse.redirect(successUrl.toString());
     }
 
-    // 初回連携フロー（onboarding含むデフォルト）
-    await updateMemberSns(discordId, {
-      line: user.username,
-      lineId: user.id,
-      lineAvatar: user.avatar,
-      lineLinkedAt: Math.floor(Date.now() / 1000),
-      lineAccessToken: tokenResponse.access_token,
-      lineRefreshToken: tokenResponse.refresh_token,
-      lineTokenExpiresAt: tokenResponse.expires_in
-        ? Math.floor(Date.now() / 1000) + tokenResponse.expires_in
-        : undefined,
-    });
+    // ── 初回連携フロー（onboarding含むデフォルト） ──
+    await updateMemberSns(discordId, snsData);
 
     const successUrl = new URL(redirectTo, origin);
     successUrl.searchParams.set("success", "line_linked");
 
-    if (isOnboarding) {
+    if (isOnboarding && !isAlumni) {
       const inGroup = await checkLineGroupMembership(user.id);
       if (!inGroup) {
         // グループ未参加 → 招待コード発行（push DMは送らず、Bot友だち追加を促す）
         await createLineInvitation(discordId, user.id);
         successUrl.searchParams.set("line_group", "not_joined");
-        if (!isFriend) {
-          successUrl.searchParams.set("not_friend", "1");
-        }
+        await appendNotFriendParam(successUrl);
       }
     }
 

--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -38,27 +38,31 @@ export async function POST() {
     );
   }
 
-  if (!member.lineId) {
-    return NextResponse.json(
-      { error: "LINE account not linked", missing: ["lineId"] },
-      { status: 400 },
-    );
-  }
+  const isAlumni = member.memberType === "卒業生";
 
-  try {
-    const isInGroup = await checkLineGroupMembership(member.lineId);
-    if (!isInGroup) {
+  if (!isAlumni) {
+    if (!member.lineId) {
       return NextResponse.json(
-        { error: "LINE group not joined", missing: ["lineGroup"] },
+        { error: "LINE account not linked", missing: ["lineId"] },
         { status: 400 },
       );
     }
-  } catch (e) {
-    console.error("LINE group membership check error during onboarding:", e);
-    return NextResponse.json(
-      { error: "Failed to verify LINE group membership" },
-      { status: 500 },
-    );
+
+    try {
+      const isInGroup = await checkLineGroupMembership(member.lineId);
+      if (!isInGroup) {
+        return NextResponse.json(
+          { error: "LINE group not joined", missing: ["lineGroup"] },
+          { status: 400 },
+        );
+      }
+    } catch (e) {
+      console.error("LINE group membership check error during onboarding:", e);
+      return NextResponse.json(
+        { error: "Failed to verify LINE group membership" },
+        { status: 500 },
+      );
+    }
   }
 
   await updateMember(session.user.id, {

--- a/app/internal/(protected)/settings/page.tsx
+++ b/app/internal/(protected)/settings/page.tsx
@@ -25,11 +25,12 @@ export default async function SettingPage({
     success?: string;
     error?: string;
     line_group?: string;
+    not_friend?: string;
   }>;
 }) {
   const session = await auth();
   const member = await getMember(session!.user!.id);
-  const { success, error, line_group } = (await searchParams) ?? {};
+  const { success, error, line_group, not_friend } = (await searchParams) ?? {};
 
   return (
     <div className="p-4 md:p-6 max-w-4xl mx-auto animate-spring-up">
@@ -57,6 +58,7 @@ export default async function SettingPage({
             </CardHeader>
             <CardContent>
               <SnsSettings
+                isAlumni={member?.memberType === "卒業生"}
                 discordUsername={member?.discordUsername ?? ""}
                 github={member?.github ?? ""}
                 githubId={member?.githubId ?? ""}
@@ -68,6 +70,7 @@ export default async function SettingPage({
                 linkedin={member?.linkedin ?? ""}
                 lineGroupPending={line_group === "not_joined"}
                 lineBotFriendUrl={process.env.LINE_BOT_FRIEND_URL}
+                isBotFriend={line_group === "not_joined" && not_friend !== "1"}
                 successMessage={success ? SUCCESS_MESSAGES[success] : undefined}
                 errorMessage={error ? ERROR_MESSAGES[error] : undefined}
               />

--- a/components/line-group-join-notice.tsx
+++ b/components/line-group-join-notice.tsx
@@ -5,11 +5,13 @@ import { Button } from "@/components/ui/button";
 
 interface LineGroupJoinNoticeProps {
   lineBotFriendUrl?: string;
+  isBotFriend?: boolean;
   onGroupJoined: () => void;
 }
 
 export function LineGroupJoinNotice({
   lineBotFriendUrl,
+  isBotFriend = false,
   onGroupJoined,
 }: LineGroupJoinNoticeProps) {
   const [checking, setChecking] = useState(false);
@@ -48,14 +50,32 @@ export function LineGroupJoinNotice({
         <p className="text-xs text-amber-700 dark:text-amber-400 mb-2">
           まずLumos公式アカウントを友だち追加してください。追加後、招待リンクが届きます。
         </p>
-        <a
-          href={lineBotFriendUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1.5 text-xs bg-[#06C755] hover:bg-[#05a848] text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
-        >
-          公式アカウントを友だち追加
-        </a>
+        <div className="flex items-center gap-2">
+          <a
+            href={lineBotFriendUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-xs bg-[#06C755] hover:bg-[#05a848] text-white font-medium px-3 py-1.5 rounded-lg transition-colors"
+          >
+            公式アカウントを友だち追加
+          </a>
+          {isBotFriend && (
+            <span className="inline-flex items-center gap-1 text-xs text-green-700 dark:text-green-400">
+              <svg
+                className="w-3.5 h-3.5"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z"
+                  clipRule="evenodd"
+                />
+              </svg>
+              追加済み
+            </span>
+          )}
+        </div>
       </div>
       <div className="flex items-center gap-2">
         <Button

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -122,6 +122,7 @@ export default function OnboardingForm({
   >({});
   const [lineGroupJoined, setLineGroupJoined] = useState(false);
   const [lineGroupCheckPending, setLineGroupCheckPending] = useState(false);
+  const [isBotFriend, setIsBotFriend] = useState(false);
 
   const [step3Error, setStep3Error] = useState("");
   const [linkedinError, setLinkedinError] = useState("");
@@ -283,7 +284,8 @@ export default function OnboardingForm({
           setLineLinked(!!data.lineId);
           setLineUsername(data.line ?? "");
           setLineAvatar(data.lineAvatar ?? "");
-          if (data.lineId) {
+          const memberTypeValue = data.memberType || cache.memberType || "";
+          if (data.lineId && memberTypeValue !== "卒業生") {
             fetch("/api/line-group/check-membership")
               .then((r) => r.json())
               .then((d) => {
@@ -313,24 +315,27 @@ export default function OnboardingForm({
 
     if (success === "line_linked") {
       setLineLinked(true);
-      const lineGroup = searchParams.get("line_group");
-      if (lineGroup === "not_joined") {
-        setLineGroupCheckPending(true);
-      } else {
-        // line_group param未指定 = APIでグループチェック
-        fetch("/api/line-group/check-membership")
-          .then((r) => r.json())
-          .then((d) => {
-            if (d.isMember) setLineGroupJoined(true);
-            else setLineGroupCheckPending(true);
-          })
-          .catch(() => {});
-      }
       fetchProfile()
         .then((data) => {
           if (data?.line) {
             setLineUsername(data.line);
             setLineAvatar(data.lineAvatar ?? "");
+          }
+          // 卒業生はグループ参加不要
+          if (data?.memberType === "卒業生") return;
+          const notFriend = searchParams.get("not_friend");
+          if (notFriend !== "1") setIsBotFriend(true);
+          const lineGroup = searchParams.get("line_group");
+          if (lineGroup === "not_joined") {
+            setLineGroupCheckPending(true);
+          } else {
+            fetch("/api/line-group/check-membership")
+              .then((r) => r.json())
+              .then((d) => {
+                if (d.isMember) setLineGroupJoined(true);
+                else setLineGroupCheckPending(true);
+              })
+              .catch(() => {});
           }
         })
         .catch(console.error);
@@ -597,14 +602,18 @@ export default function OnboardingForm({
     }
   }, [linkedinUrl]);
 
+  const isAlumni = form.memberType === "卒業生";
+
   const handleStep3Next = async () => {
-    if (!lineLinked) {
-      setStep3Error("LINEアカウントの連携は必須です");
-      return;
-    }
-    if (!lineGroupJoined) {
-      setStep3Error("LINEグループへの参加が必要です");
-      return;
+    if (!isAlumni) {
+      if (!lineLinked) {
+        setStep3Error("LINEアカウントの連携は必須です");
+        return;
+      }
+      if (!lineGroupJoined) {
+        setStep3Error("LINEグループへの参加が必要です");
+        return;
+      }
     }
     setStep3Error("");
     // Validate & normalize LinkedIn URL if provided
@@ -1124,12 +1133,14 @@ export default function OnboardingForm({
 
             {currentStep === 3 && (
               <Step3Sns
+                isAlumni={isAlumni}
                 lineLinked={lineLinked}
                 lineUsername={lineUsername}
                 lineAvatar={lineAvatar}
                 lineGroupJoined={lineGroupJoined}
                 lineGroupCheckPending={lineGroupCheckPending}
                 lineBotFriendUrl={lineBotFriendUrl}
+                isBotFriend={isBotFriend}
                 onLineGroupJoined={() => {
                   setLineGroupJoined(true);
                   setLineGroupCheckPending(false);

--- a/components/onboarding-form.tsx
+++ b/components/onboarding-form.tsx
@@ -324,7 +324,7 @@ export default function OnboardingForm({
           // 卒業生はグループ参加不要
           if (data?.memberType === "卒業生") return;
           const notFriend = searchParams.get("not_friend");
-          if (notFriend !== "1") setIsBotFriend(true);
+          setIsBotFriend(notFriend !== "1");
           const lineGroup = searchParams.get("line_group");
           if (lineGroup === "not_joined") {
             setLineGroupCheckPending(true);
@@ -373,6 +373,7 @@ export default function OnboardingForm({
       url.searchParams.delete("success");
       url.searchParams.delete("error");
       url.searchParams.delete("line_group");
+      url.searchParams.delete("not_friend");
       const params = new URLSearchParams();
       if (step) params.set("step", String(step));
       if (isPreview) params.set("preview", "");

--- a/components/onboarding/step3-sns.tsx
+++ b/components/onboarding/step3-sns.tsx
@@ -6,12 +6,14 @@ import { LineGroupJoinNotice } from "@/components/line-group-join-notice";
 import { LineIcon, GithubIcon, XIcon, LinkedInIcon } from "./types";
 
 interface Step3SnsProps {
+  isAlumni: boolean;
   lineLinked: boolean;
   lineUsername: string;
   lineAvatar: string;
   lineGroupJoined: boolean;
   lineGroupCheckPending: boolean;
   lineBotFriendUrl?: string;
+  isBotFriend?: boolean;
   onLineGroupJoined: () => void;
   githubLinked: boolean;
   githubUsername: string;
@@ -29,12 +31,14 @@ interface Step3SnsProps {
 }
 
 export function Step3Sns({
+  isAlumni,
   lineLinked,
   lineUsername,
   lineAvatar,
   lineGroupJoined,
   lineGroupCheckPending,
   lineBotFriendUrl,
+  isBotFriend,
   onLineGroupJoined,
   githubLinked,
   githubUsername,
@@ -50,6 +54,7 @@ export function Step3Sns({
   onNext,
   onBack,
 }: Step3SnsProps) {
+  const lineRequired = !isAlumni;
   return (
     <div className="p-8">
       <div className="mb-6">
@@ -57,7 +62,9 @@ export function Step3Sns({
           SNSアカウントを連携
         </h2>
         <p className="text-muted-foreground mt-1 text-sm">
-          LINEの連携は必須です。GitHubとXは任意です。
+          {isAlumni
+            ? "すべて任意です。"
+            : "LINEの連携は必須です。GitHubとXは任意です。"}
         </p>
       </div>
 
@@ -92,9 +99,11 @@ export function Step3Sns({
                   <span className="font-medium text-gray-900 dark:text-gray-100">
                     LINE
                   </span>
-                  <span className="text-[10px] bg-red-100 text-red-600 dark:bg-red-900/50 dark:text-red-400 px-1.5 py-0.5 rounded font-medium">
-                    必須
-                  </span>
+                  {lineRequired && (
+                    <span className="text-[10px] bg-red-100 text-red-600 dark:bg-red-900/50 dark:text-red-400 px-1.5 py-0.5 rounded font-medium">
+                      必須
+                    </span>
+                  )}
                 </div>
                 {lineLinked && (
                   <p className="text-xs text-green-700 dark:text-green-400 mt-0.5 truncate">
@@ -116,7 +125,7 @@ export function Step3Sns({
               {lineLinked ? "再連携" : "連携する"}
             </a>
           </div>
-          {lineLinked && lineGroupJoined && (
+          {lineLinked && lineGroupJoined && !isAlumni && (
             <div className="mt-2 flex items-center gap-1.5 text-xs text-green-700 dark:text-green-400">
               <svg
                 className="w-3.5 h-3.5"
@@ -132,12 +141,16 @@ export function Step3Sns({
               LINEグループに参加済み
             </div>
           )}
-          {lineLinked && lineGroupCheckPending && !lineGroupJoined && (
-            <LineGroupJoinNotice
-              lineBotFriendUrl={lineBotFriendUrl}
-              onGroupJoined={onLineGroupJoined}
-            />
-          )}
+          {lineLinked &&
+            lineGroupCheckPending &&
+            !lineGroupJoined &&
+            !isAlumni && (
+              <LineGroupJoinNotice
+                lineBotFriendUrl={lineBotFriendUrl}
+                isBotFriend={isBotFriend}
+                onGroupJoined={onLineGroupJoined}
+              />
+            )}
         </div>
 
         {/* GitHub — optional */}

--- a/components/sns-settings.tsx
+++ b/components/sns-settings.tsx
@@ -7,6 +7,7 @@ import { normalizeLinkedInUrl } from "@/lib/linkedin";
 import { LineGroupJoinNotice } from "@/components/line-group-join-notice";
 
 interface Props {
+  isAlumni: boolean;
   discordUsername: string;
   github: string;
   githubId: string;
@@ -18,6 +19,7 @@ interface Props {
   linkedin: string;
   lineGroupPending?: boolean;
   lineBotFriendUrl?: string;
+  isBotFriend?: boolean;
   successMessage?: string;
   errorMessage?: string;
 }
@@ -370,6 +372,7 @@ function LinkedInCard({
 }
 
 export default function SnsSettings({
+  isAlumni,
   discordUsername,
   github: initialGithub,
   githubId: initialGithubId,
@@ -381,6 +384,7 @@ export default function SnsSettings({
   linkedin: initialLinkedin,
   lineGroupPending: initialLineGroupPending,
   lineBotFriendUrl,
+  isBotFriend: initialIsBotFriend,
   successMessage,
   errorMessage,
 }: Props) {
@@ -405,7 +409,7 @@ export default function SnsSettings({
   );
 
   useEffect(() => {
-    if (lineId) {
+    if (lineId && !isAlumni) {
       fetch("/api/line-group/check-membership")
         .then((r) => r.json())
         .then((d) => {
@@ -418,7 +422,7 @@ export default function SnsSettings({
         })
         .catch(() => {});
     }
-  }, [lineId]);
+  }, [lineId, isAlumni]);
 
   const disconnect = async (provider: "github" | "x" | "line") => {
     const res = await fetch("/api/settings/sns", {
@@ -512,16 +516,17 @@ export default function SnsSettings({
             再連携は連携から2週間後に可能です。問題がある場合は管理者にお問い合わせください。
           </p>
         )}
-        {!!lineId && lineGroupJoined && (
+        {!isAlumni && !!lineId && lineGroupJoined && (
           <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400 mt-1 px-4">
             <Check className="w-3 h-3" />
             LINEグループに参加済み
           </div>
         )}
-        {!!lineId && lineGroupCheckPending && !lineGroupJoined && (
+        {!isAlumni && !!lineId && lineGroupCheckPending && !lineGroupJoined && (
           <div className="px-4">
             <LineGroupJoinNotice
               lineBotFriendUrl={lineBotFriendUrl}
+              isBotFriend={initialIsBotFriend}
               onGroupJoined={() => {
                 setLineGroupJoined(true);
                 setLineGroupCheckPending(false);
@@ -530,11 +535,14 @@ export default function SnsSettings({
             />
           </div>
         )}
-        {!!lineId && !lineGroupJoined && !lineGroupCheckPending && (
-          <div className="flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400 mt-1 px-4">
-            LINEグループに未参加
-          </div>
-        )}
+        {!isAlumni &&
+          !!lineId &&
+          !lineGroupJoined &&
+          !lineGroupCheckPending && (
+            <div className="flex items-center gap-1.5 text-xs text-amber-600 dark:text-amber-400 mt-1 px-4">
+              LINEグループに未参加
+            </div>
+          )}
       </div>
 
       {/* GitHub */}


### PR DESCRIPTION
## Summary
- 卒業生のLINE連携を任意に変更（連携自体は可能、グループ参加のみスキップ）
- LINEグループ参加フローを卒業生から除去（チェックAPI・招待コード発行・UI表示すべて）
- 設定画面のSNS連携セクションでも卒業生のグループ関連UIを非表示
- LINE OAuth callbackで卒業生はグループチェックせず即座にDB更新

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `components/onboarding/step3-sns.tsx` | 「必須」バッジ・説明文・グループUI表示を卒業生で制御 |
| `components/onboarding-form.tsx` | Step3バリデーション・グループチェックを卒業生でスキップ |
| `components/sns-settings.tsx` | 設定画面のグループ関連UIを卒業生で非表示 |
| `app/internal/(protected)/settings/page.tsx` | `isAlumni` propを `SnsSettings` に渡す |
| `app/api/auth/link/line/callback/route.ts` | 卒業生はOAuth完了時点で即DB更新（設定画面・オンボーディング両方） |
| `app/api/onboarding/route.ts` | 卒業生のLINE連携・グループ参加サーバーサイドバリデーションをスキップ |

## Test plan
- [ ] 卒業生でオンボーディングStep3: LINE連携なしで次へ進める
- [ ] 卒業生でオンボーディングStep3: LINE連携しても グループ参加を求められない
- [ ] 卒業生でオンボーディング完了: LINE未連携でも完了可能
- [ ] 卒業生で設定画面: LINE連携後にグループ関連UIが表示されない
- [ ] 卒業生で設定画面: LINE再連携がOAuth完了で即反映される
- [ ] 非卒業生: 従来通りLINE連携必須+グループ参加必須

closes #207