### PR TITLE
🐛 LINEボットのオンボーディングURLを外部ブラウザで開くように修正

### DIFF
--- a/app/api/webhook/line/route.ts
+++ b/app/api/webhook/line/route.ts
@@ -211,7 +211,7 @@ async function handleMemberJoined(event: LineWebhookEvent): Promise<void> {
         const memberDoc = await getMember(invitation.userId);
         const isOnboarding = memberDoc && !isOnboardingComplete(memberDoc);
         const onboardingUrl = isOnboarding
-          ? `${process.env.AUTH_URL ?? "http://localhost:3000"}/internal/onboarding`
+          ? `${process.env.AUTH_URL ?? "http://localhost:3000"}/internal/onboarding?openExternalBrowser=1`
           : undefined;
 
         await sendLineGroupJoinedDM(member.userId, onboardingUrl);


### PR DESCRIPTION
## Summary
- LINEボットから送信される「オンボーディングを続ける」ボタンのURLに `?openExternalBrowser=1` を付与
- LINEブラウザではなくOSデフォルトブラウザで開くようになり、OAuth2 PKCE認証の失敗を回避

Closes #209

## Test plan
- [ ] LINEボットからオンボーディングURLを含むメッセージを受信し、「オンボーディングを続ける」ボタンを押す
- [ ] LINEブラウザではなくOSデフォルトブラウザで開かれることを確認
- [ ] OAuth2認証が正常に完了することを確認