### PR TITLE
🔐 退会確定後に最終確認DMのボタンを無効化

### DIFF
--- a/app/api/optout/request/route.ts
+++ b/app/api/optout/request/route.ts
@@ -10,7 +10,9 @@ import { getMember, isMemberOptedOut } from "@/lib/members";
 import { isValidSnowflake } from "@/lib/auth";
 import {
   sendDiscordDm,
+  editDiscordDm,
   buildOptoutConfirmRequestMessage,
+  buildOptoutConfirmRequestButtons,
 } from "@/lib/discord-dm";
 
 const REASON_SET = new Set<string>(OPTOUT_REASON_VALUES);
@@ -102,16 +104,37 @@ export async function POST(request: NextRequest) {
   }
 
   // Step 2 の最終確認 DM を送信
+  // 1. ボタン無しで送信 → messageId を取得
+  // 2. PATCH で messageId を埋め込んだ finalizeUrl ボタンを後付けする
+  // これにより確定後に同じ messageId でボタンを削除して誤クリックを防げる
   const displayName =
     member?.discordUsername ?? member?.nickname ?? "Discord ユーザー";
-  const finalizeUrl = getOptoutFinalizeUrl(discordId);
+  let messageId: string;
   try {
-    await sendDiscordDm(
+    const sent = await sendDiscordDm(
       discordId,
-      buildOptoutConfirmRequestMessage(displayName, finalizeUrl),
+      buildOptoutConfirmRequestMessage(displayName),
     );
+    messageId = sent.messageId;
   } catch (e) {
     console.error("Failed to send opt-out confirm DM:", e);
+    return NextResponse.json(
+      {
+        error:
+          "Discordへの確認DM送信に失敗しました。DMを受信できる設定かご確認のうえ、再度お試しください。",
+      },
+      { status: 502 },
+    );
+  }
+
+  // messageId 埋め込み済みのボタンを後付け。失敗したらボタン無しで届いてしまうので 502
+  try {
+    const finalizeUrl = getOptoutFinalizeUrl(discordId, messageId);
+    await editDiscordDm(discordId, messageId, {
+      components: buildOptoutConfirmRequestButtons(finalizeUrl),
+    });
+  } catch (e) {
+    console.error("Failed to attach confirm button:", e);
     return NextResponse.json(
       {
         error:

--- a/app/optout/confirm/[discordId]/[exp]/[messageId]/[sig]/page.tsx
+++ b/app/optout/confirm/[discordId]/[exp]/[messageId]/[sig]/page.tsx
@@ -15,6 +15,7 @@ import {
 import { isValidSnowflake } from "@/lib/auth";
 import {
   sendDiscordDm,
+  editDiscordDm,
   buildOptoutLinkReissueMessage,
   buildOptoutCompletedMessage,
 } from "@/lib/discord-dm";
@@ -73,9 +74,14 @@ async function reissueAndRender(discordId: string) {
 export default async function OptoutConfirmPage({
   params,
 }: {
-  params: Promise<{ discordId: string; exp: string; sig: string }>;
+  params: Promise<{
+    discordId: string;
+    exp: string;
+    messageId: string;
+    sig: string;
+  }>;
 }) {
-  const { discordId, exp, sig } = await params;
+  const { discordId, exp, messageId, sig } = await params;
 
   if (!isValidSnowflake(discordId)) {
     return (
@@ -94,7 +100,7 @@ export default async function OptoutConfirmPage({
     redirect("/optout/done");
   }
 
-  const result = verifyOptoutConfirm(discordId, exp, sig);
+  const result = verifyOptoutConfirm(discordId, exp, sig, messageId);
   if (!result.ok) {
     // invalid も expired も同じ: Step 1 からやり直しリンクを再送
     return reissueAndRender(discordId);
@@ -124,6 +130,13 @@ export default async function OptoutConfirmPage({
         description="サーバーで保存に失敗しました。しばらくしてからもう一度お試しください。"
       />
     );
+  }
+
+  // 元の最終確認 DM のボタンを無効化 (再加入後に誤って再押下されるのを防ぐ)
+  try {
+    await editDiscordDm(discordId, messageId, { components: [] });
+  } catch (e) {
+    console.error("Failed to strip buttons from confirm DM:", e);
   }
 
   // 完了通知 DM (失敗してもユーザー体験には影響しないので握りつぶしてログのみ)

--- a/docs/optout-flow.md
+++ b/docs/optout-flow.md
@@ -133,7 +133,9 @@ sequenceDiagram
     API->>FS: getMember(discordId)
     FS-->>API: members.optedOut 未設定
     API->>FS: recordOptoutSurvey(discordId, survey)
-    API->>DC: sendDiscordDm(discordId, buildOptoutConfirmRequestMessage(...))
+    API->>DC: sendDiscordDm(discordId, buildOptoutConfirmRequestMessage(...))  // ボタン無し
+    DC-->>API: { messageId }
+    API->>DC: editDiscordDm(discordId, messageId, components: ボタン with finalizeUrl(messageId 埋め込み))
     DC-->>API: 成功
     API-->>F: { success: true }
     F->>F: router.replace("/optout/submitted")
@@ -148,18 +150,19 @@ sequenceDiagram
 
 ## 4. Step 2 技術詳細: 最終確認 (Discord DM → Web)
 
-### 画面遷移 — `app/optout/confirm/[discordId]/[exp]/[sig]/page.tsx`
+### 画面遷移 — `app/optout/confirm/[discordId]/[exp]/[messageId]/[sig]/page.tsx`
 
 ```mermaid
 flowchart TD
-    Start["/optout/confirm/:discordId/:exp/:sig"] --> V1{"discordId<br/>Snowflake 妥当?"}
+    Start["/optout/confirm/:discordId/:exp/:messageId/:sig"] --> V1{"discordId<br/>Snowflake 妥当?"}
     V1 -->|No| ErrInvalid["リンクを認識できませんでした"]
     V1 -->|Yes| V2{"isDiscordIdOptedOut<br/>既に確定済み?"}
     V2 -->|Yes| RedirDone["/optout/done へ redirect<br/>冪等"]
     V2 -->|No| V3{"verifyOptoutConfirm<br/>sig と exp 妥当?"}
     V3 -->|No - invalid または expired| Reissue["Step 1 用 退会リンクを<br/>Discord DM に再送"]
     V3 -->|Yes| Write["Firestore 書き込み<br/>recordOptoutSubmission<br/>markOptoutSurveyConfirmed<br/>markMemberOptedOut"]
-    Write -->|成功| RedirDone
+    Write -->|成功| PatchDM["editDiscordDm で元 DM の<br/>ボタンを無効化 (components: [])"]
+    PatchDM --> RedirDone
     Write -->|失敗| Err["処理に失敗しました カード"]
 ```
 
@@ -170,6 +173,7 @@ flowchart TD
 - `noindex, nofollow` の `robots` メタ + `dynamic = "force-dynamic"` でブラウザプリフェッチ・クロール副作用を抑止。
 - **invalid と expired で挙動を分けない**: どちらも Step 1 からやり直すべき状況なので、新しい退会リンクを送信する。
 - **副作用完了後は必ず `/optout/done` にリダイレクト**。ユーザーが完了画面でリロードしても、署名付き URL が再実行されず副作用が重複しない。既に確定済みだった場合も同じページに飛ばして、ブラウザ履歴の巻き戻し耐性も確保している。
+- **確定後に元 Confirm DM のボタンを削除する**。再加入→同じ DM のボタンを誤って再押下してしまうと、期限が20分以内なら再び退会確定してしまう。その事故を防ぐため、`messageId` を URL payload に埋めておき (HMAC で改竄検出)、確定時に `PATCH /channels/{channelId}/messages/{messageId}` で components を空配列に差し替える。編集失敗はログのみで握りつぶす (退会自体は成功扱い)。
 
 ### 書き込まれるもの
 
@@ -285,7 +289,7 @@ sequenceDiagram
 | ---------------------------------- | ------------------------------------ | ---------------------------------------------------------------- |
 | `buildRegistrationNudgeMessage`    | 未登録者への登録案内                 | 登録: `/internal` / 退会: `/optout/{discordId}/{sig}`            |
 | `buildOnboardingNudgeMessage`      | オンボーディング途中の人への再開案内 | 再開: `/internal/onboarding` / 退会: `/optout/{discordId}/{sig}` |
-| `buildOptoutConfirmRequestMessage` | Step 1 送信後の最終確認 DM           | 最終確認: `/optout/confirm/{discordId}/{exp}/{sig}`              |
+| `buildOptoutConfirmRequestMessage` | Step 1 送信後の最終確認 DM           | 最終確認: `/optout/confirm/{discordId}/{exp}/{messageId}/{sig}`  |
 | `buildOptoutLinkReissueMessage`    | 古いリンク検知時の再発行 DM          | 退会: `/optout/{discordId}/{sig}` (最新 sig)                     |
 
 ---

--- a/lib/admin/dev-tools-actions.ts
+++ b/lib/admin/dev-tools-actions.ts
@@ -5,6 +5,7 @@ import { isProduction } from "@/lib/env";
 import { getGuildMembers, type DiscordGuildMember } from "@/lib/discord-guild";
 import {
   sendDiscordDm,
+  editDiscordDm,
   buildWelcomeMessage,
   buildOnboardingCompleteMessage,
   buildLoginMessage,
@@ -12,6 +13,7 @@ import {
   buildRegistrationNudgeMessage,
   buildOnboardingNudgeMessage,
   buildOptoutConfirmRequestMessage,
+  buildOptoutConfirmRequestButtons,
   buildOptoutCompletedMessage,
   buildRejoinCompletedMessage,
   type DiscordMessagePayload,
@@ -65,10 +67,7 @@ function buildMessagePayload(
     case "onboarding_nudge":
       return buildOnboardingNudgeMessage(displayName, discordId);
     case "optout_confirm_request":
-      return buildOptoutConfirmRequestMessage(
-        displayName,
-        getOptoutFinalizeUrl(discordId),
-      );
+      return buildOptoutConfirmRequestMessage(displayName);
     case "optout_completed":
       return buildOptoutCompletedMessage(displayName);
     case "rejoin_completed":
@@ -116,7 +115,15 @@ export async function sendTestDiscordMessage(
       "テストユーザー",
       targetDiscordId,
     );
-    await sendDiscordDm(targetDiscordId, payload);
+    const sent = await sendDiscordDm(targetDiscordId, payload);
+
+    // 最終確認 DM は本番と同じ2段階 (messageId 判明後にボタン後付け) で送る
+    if (messageType === "optout_confirm_request") {
+      const finalizeUrl = getOptoutFinalizeUrl(targetDiscordId, sent.messageId);
+      await editDiscordDm(targetDiscordId, sent.messageId, {
+        components: buildOptoutConfirmRequestButtons(finalizeUrl),
+      });
+    }
     return { success: true };
   } catch (e) {
     return {

--- a/lib/discord-dm.ts
+++ b/lib/discord-dm.ts
@@ -596,9 +596,13 @@ export function buildRejoinCompletedMessage(
  * Step 2 確認用 DM: Web 上で退会リクエストを送信したユーザーに、本人確認として
  * 別途 DM で最終確認リンク (20 分有効) を送る
  */
+/**
+ * Step 2 確認 DM の本文 embed。finalizeUrl は送信時点では messageId が未知のため、
+ * components (ボタン) は別途 {@link buildOptoutConfirmRequestButtons} で生成して
+ * PATCH で後付けする。
+ */
 export function buildOptoutConfirmRequestMessage(
   username: string,
-  finalizeUrl: string,
 ): DiscordMessagePayload {
   return {
     embeds: [
@@ -616,21 +620,26 @@ export function buildOptoutConfirmRequestMessage(
         footer: { text: FOOTER_TEXT },
       },
     ],
-    components: [
-      {
-        type: 1,
-        components: [
-          {
-            type: 2,
-            style: 5,
-            label: "退会処理を完了させる",
-            url: finalizeUrl,
-            emoji: { name: "✅" },
-          },
-        ],
-      },
-    ],
   };
+}
+
+export function buildOptoutConfirmRequestButtons(
+  finalizeUrl: string,
+): DiscordActionRow[] {
+  return [
+    {
+      type: 1,
+      components: [
+        {
+          type: 2,
+          style: 5,
+          label: "退会処理を完了させる",
+          url: finalizeUrl,
+          emoji: { name: "✅" },
+        },
+      ],
+    },
+  ];
 }
 
 // --- Discord API ---
@@ -662,7 +671,7 @@ async function createDmChannel(recipientId: string): Promise<string> {
 async function sendChannelMessage(
   channelId: string,
   payload: DiscordMessagePayload,
-): Promise<void> {
+): Promise<{ messageId: string }> {
   const botToken = process.env.DISCORD_BOT_TOKEN;
   if (!botToken) {
     throw new Error("DISCORD_BOT_TOKEN is not configured");
@@ -684,12 +693,49 @@ async function sendChannelMessage(
     const error = await response.text();
     throw new Error(`Failed to send DM message: ${response.status} ${error}`);
   }
+
+  const data = (await response.json()) as { id: string };
+  return { messageId: data.id };
 }
 
 export async function sendDiscordDm(
   recipientId: string,
   payload: DiscordMessagePayload,
-): Promise<void> {
+): Promise<{ channelId: string; messageId: string }> {
   const channelId = await createDmChannel(recipientId);
-  await sendChannelMessage(channelId, payload);
+  const { messageId } = await sendChannelMessage(channelId, payload);
+  return { channelId, messageId };
+}
+
+/**
+ * 既に送信済みの DM メッセージを編集する。components を空配列にすればボタン無効化可能。
+ * Bot 自身が送信したメッセージのみ編集可能。
+ */
+export async function editDiscordDm(
+  recipientId: string,
+  messageId: string,
+  payload: Partial<DiscordMessagePayload>,
+): Promise<void> {
+  const botToken = process.env.DISCORD_BOT_TOKEN;
+  if (!botToken) {
+    throw new Error("DISCORD_BOT_TOKEN is not configured");
+  }
+
+  const channelId = await createDmChannel(recipientId);
+  const response = await fetch(
+    `${DISCORD_API_BASE}/channels/${channelId}/messages/${messageId}`,
+    {
+      method: "PATCH",
+      headers: {
+        Authorization: `Bot ${botToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    },
+  );
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(`Failed to edit DM message: ${response.status} ${error}`);
+  }
 }

--- a/lib/discord-optout.ts
+++ b/lib/discord-optout.ts
@@ -67,7 +67,7 @@ export type OptoutRequestDecodeResult =
   | { ok: false; error: OptoutTokenError; discordId?: string };
 
 export type OptoutConfirmDecodeResult =
-  | { ok: true; discordId: string; exp: number }
+  | { ok: true; discordId: string; exp: number; messageId: string }
   | { ok: false; error: OptoutTokenError; discordId?: string };
 
 // --- Step 1 (request) ---
@@ -96,34 +96,42 @@ export function verifyOptoutRequest(
 
 // --- Step 2 (confirm) ---
 
-export function signOptoutConfirm(discordId: string, exp: number): string {
-  return sign(`${CONFIRM_LABEL}|${discordId}|${exp}`);
+export function signOptoutConfirm(
+  discordId: string,
+  exp: number,
+  messageId: string,
+): string {
+  return sign(`${CONFIRM_LABEL}|${discordId}|${exp}|${messageId}`);
 }
 
-/** `/optout/confirm/{discordId}/{exp}/{sig}` を検証 */
+/** `/optout/confirm/{discordId}/{exp}/{messageId}/{sig}` を検証 */
 export function verifyOptoutConfirm(
   discordId: string,
   expRaw: string,
   sig: string,
+  messageId: string,
 ): OptoutConfirmDecodeResult {
   if (!process.env.AUTH_SECRET) {
     return { ok: false, error: "missing_secret", discordId };
   }
-  if (!discordId || !expRaw || !sig) {
+  if (!discordId || !expRaw || !sig || !messageId) {
     return { ok: false, error: "invalid", discordId };
   }
   if (!/^\d{1,13}$/.test(expRaw)) {
     return { ok: false, error: "invalid", discordId };
   }
+  if (!/^\d{1,25}$/.test(messageId)) {
+    return { ok: false, error: "invalid", discordId };
+  }
   const exp = Number(expRaw);
-  const expected = signOptoutConfirm(discordId, exp);
+  const expected = signOptoutConfirm(discordId, exp, messageId);
   if (!timingSafeEqual(expected, sig)) {
     return { ok: false, error: "invalid", discordId };
   }
   if (exp * 1000 < Date.now()) {
     return { ok: false, error: "expired", discordId };
   }
-  return { ok: true, discordId, exp };
+  return { ok: true, discordId, exp, messageId };
 }
 
 // --- URL helpers ---
@@ -137,10 +145,18 @@ export function getOptoutRequestUrl(discordId: string): string {
   return `${getBaseUrl()}/optout/${discordId}/${signOptoutRequest(discordId)}`;
 }
 
-/** Step 2 のランディング URL (exp 20 分後) */
-export function getOptoutFinalizeUrl(discordId: string): string {
+/**
+ * Step 2 のランディング URL (exp 20 分後)。
+ * messageId は元の Confirm DM のメッセージIDで、確定後にそのメッセージを編集して
+ * 誤クリックを防ぐのに使う。URL には平文で含むが HMAC 署名の material にも入れて改竄検出する。
+ */
+export function getOptoutFinalizeUrl(
+  discordId: string,
+  messageId: string,
+): string {
   const exp = Math.floor(Date.now() / 1000) + OPTOUT_CONFIRM_TTL_SECONDS;
-  return `${getBaseUrl()}/optout/confirm/${discordId}/${exp}/${signOptoutConfirm(discordId, exp)}`;
+  const sig = signOptoutConfirm(discordId, exp, messageId);
+  return `${getBaseUrl()}/optout/confirm/${discordId}/${exp}/${messageId}/${sig}`;
 }
 
 // --- Firestore: optout_submissions ---


### PR DESCRIPTION
## Summary

再入会直後に同じ最終確認 DM のボタンを誤って再押下されると、トークンが 20 分以内ならまた退会処理が走ってしまう問題への対応。

確定処理の完了と同時に元 DM のボタン (components) を空配列に差し替え、再クリックできないようにする。

## 実装ポイント

- `confirm` URL 構造を `/optout/confirm/:discordId/:exp/:messageId/:sig` に拡張
- `messageId` も HMAC の material に含めて改竄検出
- Step 1 API (`/api/optout/request`) は先にボタン無しで DM を送信 → レスポンスから `messageId` を取得 → `PATCH` で `finalizeUrl` 埋め込み済みボタンを後付け
- 確定 page で `editDiscordDm(components: [])` を呼んでボタン削除 (失敗はログのみで握り潰し、退会自体は成功)
- dev-tools の `optout_confirm_request` 送信も本番と同じ 2 段階フローに合わせる
- ドキュメント (`docs/optout-flow.md`) を更新

## Test plan

- [ ] Step 1 を送信すると確認 DM が届き、ボタンから `/optout/confirm/.../{messageId}/{sig}` へ遷移できる
- [ ] 確定成功後、元 DM のボタンが消えて押せなくなっている
- [ ] 再入会後に元 DM の(消えたはずの)ボタン領域を触っても何も起きない
- [ ] 20 分超過後にボタンを押したら再発行 DM が飛ぶ (既存挙動維持)
- [ ] dev-tools から `optout_confirm_request` を送信するとボタンが正しく現れる