### PR TITLE
💄 再入会ボタンを控えめなoutlineスタイルに

### DIFF
--- a/components/optout/rejoin-button.tsx
+++ b/components/optout/rejoin-button.tsx
@@ -39,7 +39,7 @@ export default function RejoinButton() {
         type="button"
         onClick={handleRejoin}
         disabled={isPending}
-        className="inline-flex w-full items-center justify-center rounded-md bg-gradient-to-r from-emerald-400 to-teal-400 px-4 py-2.5 text-sm font-semibold text-white shadow-lg shadow-emerald-400/30 transition-all hover:from-emerald-300 hover:to-teal-300 hover:shadow-emerald-400/50 disabled:cursor-not-allowed disabled:opacity-60"
+        className="inline-flex w-full items-center justify-center rounded-md bg-emerald-500 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-60"
       >
         {isPending ? "処理中…" : "✨ 再入会する"}
       </button>


### PR DESCRIPTION
## Summary

退会完了ページの「✨ 再入会する」ボタンが emerald→teal グラデーション + shadow で眩しすぎたので、明るさは保ちつつトーンを整えた。

## Before → After

- Before: `bg-gradient-to-r from-emerald-400 to-teal-400 text-white shadow-lg shadow-emerald-400/30`
- After: `bg-emerald-500 text-white shadow-sm hover:bg-emerald-600`

ベタ塗りの emerald-500 + 控えめな shadow + 白文字に着地。アクション性を保ちつつ視覚的なノイズを抑えた。

## Test plan

- [x] `/optout/completed` のボタン外観が明るすぎず暗すぎない
- [x] hover で `emerald-600` に暗転する
- [x] disabled 時は opacity-60 になる