### PR TITLE
💄 オンボーディングフォームの必須/任意表記とUIを改善

### DIFF
--- a/components/onboarding/step1-basic-info.tsx
+++ b/components/onboarding/step1-basic-info.tsx
@@ -174,15 +174,28 @@ export function Step1BasicInfo({
 
         <div className="space-y-1.5 animate-[fadeInUp_300ms_120ms_ease_both]">
           <Label htmlFor="birthDate">誕生日</Label>
-          <Input
-            id="birthDate"
-            type="date"
-            value={form.birthDate}
-            onChange={(e) =>
-              setForm((f) => ({ ...f, birthDate: e.target.value }))
-            }
-            className="block w-full"
-          />
+          <div className="flex gap-2">
+            <Input
+              id="birthDate"
+              type="date"
+              value={form.birthDate}
+              onChange={(e) =>
+                setForm((f) => ({ ...f, birthDate: e.target.value }))
+              }
+              className="block w-full"
+            />
+            {form.birthDate && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={() => setForm((f) => ({ ...f, birthDate: "" }))}
+                className="text-muted-foreground hover:text-foreground flex-shrink-0"
+              >
+                リセット
+              </Button>
+            )}
+          </div>
         </div>
 
         <div className="space-y-1.5 animate-[fadeInUp_300ms_210ms_ease_both]">

--- a/components/onboarding/step2-enrollment.tsx
+++ b/components/onboarding/step2-enrollment.tsx
@@ -244,7 +244,7 @@ export function Step2Enrollment({
           <Label>
             {form.memberType === "院生"
               ? "横浜国立大学大学院への入学年度"
-              : "横浜国立大学への入学年度"}
+              : "横浜国立大学への入学年度"}{" "}
             <span className="text-red-500">*</span>
           </Label>
           <div className="flex gap-2">
@@ -408,7 +408,9 @@ export function Step2Enrollment({
                 </p>
 
                 <div className="space-y-1.5">
-                  <Label htmlFor="undergradFaculty">所属学部</Label>
+                  <Label htmlFor="undergradFaculty">
+                    所属学部 <span className="text-red-500">*</span>
+                  </Label>
                   <select
                     id="undergradFaculty"
                     value={form.undergradFaculty}
@@ -445,7 +447,9 @@ export function Step2Enrollment({
                 </div>
 
                 <div className="space-y-1.5">
-                  <Label>学部への入学年度</Label>
+                  <Label>
+                    学部への入学年度 <span className="text-red-500">*</span>
+                  </Label>
                   <div className="flex gap-2">
                     <select
                       value={form.undergradAdmissionYear}
@@ -586,7 +590,9 @@ export function Step2Enrollment({
                   </p>
 
                   <div className="space-y-1.5">
-                    <Label htmlFor="undergradFacultyGrad">所属学部</Label>
+                    <Label htmlFor="undergradFacultyGrad">
+                      所属学部 <span className="text-red-500">*</span>
+                    </Label>
                     <select
                       id="undergradFacultyGrad"
                       value={form.undergradFaculty}
@@ -623,7 +629,9 @@ export function Step2Enrollment({
                   </div>
 
                   <div className="space-y-1.5">
-                    <Label>学部への入学年度</Label>
+                    <Label>
+                      学部への入学年度 <span className="text-red-500">*</span>
+                    </Label>
                     <div className="flex gap-2">
                       <select
                         value={form.undergradAdmissionYear}

--- a/lib/discord-dm.ts
+++ b/lib/discord-dm.ts
@@ -532,7 +532,7 @@ export function buildOptoutCompletedMessage(
             type: 2,
             style: 5,
             label: "Lumos公式サイトはこちら",
-            url: "https://lumos-ynu.jp",
+            url: getBaseUrl(),
             emoji: { name: "🌐" },
           },
         ],


### PR DESCRIPTION
## Summary

- Step2: `undergradFaculty` / `undergradAdmissionYear` のラベルに赤 `*` を追加。既にフロント側バリデーション (`handleStep2Next`) で必須扱いだったが、UI上は任意項目に見えてしまっていた
- Step2: 「横浜国立大学(大学院)への入学年度」ラベルの `*` 直前に半角スペースを追加し、他のラベルと表記ゆれを解消
- Step1: 誕生日入力欄に「リセット」ボタンを追加（値が入っているときのみ表示）。誕生日は任意項目のため、一度入力した日付を空に戻せる導線を提供
- `lib/discord-dm.ts`: 退会完了DMの「Lumos公式サイト」ボタンURLを `getBaseUrl()` に変更して他メッセージと統一

## Test plan

- [ ] `just dev` でオンボーディングに入り、Step2 で種別「院生」→「学部から進学しましたか？」→「はい」で `所属学部` / `学部への入学年度` ラベルに赤 `*` が付いていること
- [ ] 同様に「卒業生」＋学府を選択→「学部に在籍しましたか？」→「はい」のルートでも `*` が付いていること
- [ ] 入学年度ラベルの `*` が他ラベルと同じ間隔で表示されていること
- [ ] Step1 の誕生日欄に日付を入れると右側に「リセット」ボタンが現れ、押下で空に戻ること
- [ ] 誕生日が空のときはリセットボタンが表示されないこと