### PR TITLE
🔔 入会/退会時に運営チャンネルへ Discord 通知を送信

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,11 @@ ADMIN_ROLE_ID="1234567890"
 # 昨年度メンバーロールのID（継続メンバー判定に使用）
 RETURNING_MEMBER_ROLE_ID="1234567890"
 
+# 運営チャンネル通知用の Discord Webhook URL（入会/退会などの運営向け通知を投稿）
+# Discord チャンネル > 連携サービス > ウェブフック から作成
+# 空文字の場合は通知をスキップ
+ADMIN_NOTIFICATION_CHANNEL_WEBHOOK=""
+
 # --- GitHub OAuth (SNS連携) ---
 # GitHub Developer Settings > OAuth Apps で取得
 # Callback URL: http://localhost:3000/api/auth/link/github/callback

--- a/app/api/onboarding/route.ts
+++ b/app/api/onboarding/route.ts
@@ -5,6 +5,8 @@ import {
   sendDiscordDm,
   buildOnboardingCompleteMessage,
   calcProfileCompletion,
+  notifyAdminChannel,
+  buildAdminOnboardingCompletedNotification,
 } from "@/lib/discord-dm";
 import { checkLineGroupMembership } from "@/lib/line-invite";
 
@@ -85,6 +87,19 @@ export async function POST() {
     );
     sendDiscordDm(session.user.id, payload).catch((e) => {
       console.error("Failed to send onboarding complete DM:", e);
+    });
+
+    notifyAdminChannel(
+      buildAdminOnboardingCompletedNotification({
+        discordId: session.user.id,
+        discordUsername: updatedMember.discordUsername,
+        nickname: updatedMember.nickname,
+        lastName: updatedMember.lastName,
+        firstName: updatedMember.firstName,
+        memberType: updatedMember.memberType,
+      }),
+    ).catch((e) => {
+      console.error("Failed to notify admin channel (onboarding):", e);
     });
   }
 

--- a/app/optout/confirm/[discordId]/[exp]/[messageId]/[sig]/page.tsx
+++ b/app/optout/confirm/[discordId]/[exp]/[messageId]/[sig]/page.tsx
@@ -18,6 +18,8 @@ import {
   editDiscordDm,
   buildOptoutLinkReissueMessage,
   buildOptoutCompletedMessage,
+  notifyAdminChannel,
+  buildAdminOptoutNotification,
 } from "@/lib/discord-dm";
 import { fetchDiscordDisplayName } from "@/lib/discord";
 import OptoutStatusCard from "@/components/optout/status-card";
@@ -140,16 +142,31 @@ export default async function OptoutConfirmPage({
   }
 
   // 完了通知 DM (失敗してもユーザー体験には影響しないので握りつぶしてログのみ)
+  const member = await getMember(discordId);
+  const displayName =
+    member?.discordUsername ??
+    member?.nickname ??
+    (await fetchDiscordDisplayName(discordId)) ??
+    "Discord ユーザー";
   try {
-    const member = await getMember(discordId);
-    const displayName =
-      member?.discordUsername ??
-      member?.nickname ??
-      (await fetchDiscordDisplayName(discordId)) ??
-      "Discord ユーザー";
     await sendDiscordDm(discordId, buildOptoutCompletedMessage(displayName));
   } catch (e) {
     console.error("Failed to send opt-out completion DM:", e);
+  }
+
+  // 運営チャンネル通知 (webhook 未設定時は no-op)
+  try {
+    await notifyAdminChannel(
+      buildAdminOptoutNotification({
+        discordId,
+        discordUsername: member?.discordUsername ?? displayName,
+        nickname: member?.nickname,
+        lastName: member?.lastName,
+        firstName: member?.firstName,
+      }),
+    );
+  } catch (e) {
+    console.error("Failed to notify admin channel (optout):", e);
   }
 
   // 副作用完了後は専用ページへリダイレクト (リロードでも副作用が再走しないように)

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -151,6 +151,15 @@ resource "google_cloud_run_service" "web" {
             }
           }
         }
+        env {
+          name = "ADMIN_NOTIFICATION_CHANNEL_WEBHOOK"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.per_env["admin-notification-channel-webhook-${each.key}"].secret_id
+              key  = "latest"
+            }
+          }
+        }
       }
     }
   }

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -15,7 +15,8 @@ locals {
     "line-support-friend-url",
     "line-webhook-secret",
     "line-channel-access-token",
-    "line-bot-friend-url"
+    "line-bot-friend-url",
+    "admin-notification-channel-webhook"
   ]
 
   # Build a flat map: "github-oauth-secret-dev" => { secret_suffix, env }

--- a/lib/discord-dm.ts
+++ b/lib/discord-dm.ts
@@ -708,6 +708,112 @@ export async function sendDiscordDm(
 }
 
 /**
+ * 運営チャンネルへ webhook 経由で通知を送る。
+ * ADMIN_NOTIFICATION_CHANNEL_WEBHOOK が未設定（空文字 / 空白のみ）の場合は no-op。
+ * 呼び出し側が例外を受け取らないよう fire-and-forget 前提で使うこと。
+ */
+export async function notifyAdminChannel(
+  payload: DiscordMessagePayload,
+): Promise<void> {
+  const webhookUrl = process.env.ADMIN_NOTIFICATION_CHANNEL_WEBHOOK?.trim();
+  if (!webhookUrl) return;
+
+  const response = await fetch(webhookUrl, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(
+      `Failed to notify admin channel: ${response.status} ${error}`,
+    );
+  }
+}
+
+// --- Admin notification message builders ---
+
+const ADMIN_JOIN_COLOR = 0x57f287; // Discord Green
+const ADMIN_OPTOUT_COLOR = 0xed4245; // Discord Red
+
+export function buildAdminOnboardingCompletedNotification(member: {
+  discordId: string;
+  discordUsername: string;
+  nickname?: string | null;
+  lastName?: string | null;
+  firstName?: string | null;
+  memberType?: string | null;
+}): DiscordMessagePayload {
+  const fullName =
+    [member.lastName, member.firstName].filter(Boolean).join(" ") || "—";
+  const fields: DiscordEmbedField[] = [
+    {
+      name: "Discord",
+      value: `${member.discordUsername} (<@${member.discordId}>)`,
+      inline: false,
+    },
+    { name: "氏名", value: fullName, inline: true },
+  ];
+  if (member.nickname) {
+    fields.push({ name: "ニックネーム", value: member.nickname, inline: true });
+  }
+  if (member.memberType) {
+    fields.push({
+      name: "メンバー区分",
+      value: member.memberType,
+      inline: true,
+    });
+  }
+
+  return {
+    embeds: [
+      {
+        title: "新メンバー入会通知",
+        description: "オンボーディングが完了しました。",
+        color: ADMIN_JOIN_COLOR,
+        fields,
+        footer: { text: FOOTER_TEXT },
+      },
+    ],
+  };
+}
+
+export function buildAdminOptoutNotification(member: {
+  discordId: string;
+  discordUsername: string;
+  nickname?: string | null;
+  lastName?: string | null;
+  firstName?: string | null;
+}): DiscordMessagePayload {
+  const fullName =
+    [member.lastName, member.firstName].filter(Boolean).join(" ") || "—";
+  const fields: DiscordEmbedField[] = [
+    {
+      name: "Discord",
+      value: `${member.discordUsername} (<@${member.discordId}>)`,
+      inline: false,
+    },
+    { name: "氏名", value: fullName, inline: true },
+  ];
+  if (member.nickname) {
+    fields.push({ name: "ニックネーム", value: member.nickname, inline: true });
+  }
+
+  return {
+    embeds: [
+      {
+        title: "メンバー退会通知",
+        description: "退会処理が完了しました。",
+        color: ADMIN_OPTOUT_COLOR,
+        fields,
+        footer: { text: FOOTER_TEXT },
+      },
+    ],
+  };
+}
+
+/**
  * 既に送信済みの DM メッセージを編集する。components を空配列にすればボタン無効化可能。
  * Bot 自身が送信したメッセージのみ編集可能。
  */


### PR DESCRIPTION
## Summary
- `ADMIN_NOTIFICATION_CHANNEL_WEBHOOK` を新規追加し、オンボーディング完了時・退会確定時に運営チャンネル向け webhook へ embed を送信
- webhook 送信ユーティリティ `notifyAdminChannel()` と通知用 embed ビルダー 2 種を `lib/discord-dm.ts` に追加（未設定時は no-op）
- Terraform (`infra/secrets.tf` / `infra/cloud_run.tf`) に dev/stg/prd 各環境の Secret Manager secret とマウント設定を追加

## 動機
運営が新規メンバーの入会・退会をリアルタイムに把握する手段が無かった。Bot 経由の個別 DM は実装済みだったが、運営向けチャンネルへの集約通知は未整備だったため。

## 通知内容
- **新メンバー入会通知** (緑): Discord メンション / 氏名 / ニックネーム / メンバー区分
- **メンバー退会通知** (赤): Discord メンション / 氏名 / ニックネーム

## 運用側の残作業
1. 各環境で Discord チャンネル > 連携サービス > Webhook を作成
2. \`gcloud secrets versions add lumos-ynu-admin-notification-channel-webhook-{env} --data-file=-\` で URL を投入
3. Cloud Run に新リビジョンをデプロイ (secret 再読込)

※ Terraform は既に apply 済み。各 secret には初期 version (空白プレースホルダ) のみ入っている状態。

## Test plan
- [ ] webhook URL 未設定 (= 空白) で既存 DM 送信フローが壊れないことを確認
- [ ] dev 環境で webhook URL を投入し、オンボーディング完了時に運営チャンネルへ通知が届くか確認
- [ ] dev 環境で退会フロー (Step 2 確定) を走らせ、運営チャンネルへ通知が届くか確認
- [ ] webhook 呼び出し失敗時にユーザー体験 (onboarding API レスポンス / optout 完了画面) へ影響しないことを確認