### PR TITLE
🐛 #147 Cloud RunビルドでコミットSHAを渡す

### DIFF
--- a/.github/workflows/deploy-cloudrun-dev.yaml
+++ b/.github/workflows/deploy-cloudrun-dev.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ./cloudrun/Dockerfile
           build-args: |
             NEXT_PUBLIC_APP_ENV=development
+            COMMIT_SHA=${{ github.sha }}
 
       - name: Download Cloud Run Service YAML
         run: |

--- a/.github/workflows/deploy-cloudrun-pr.yaml
+++ b/.github/workflows/deploy-cloudrun-pr.yaml
@@ -46,6 +46,7 @@ jobs:
           file: ./cloudrun/Dockerfile
           build-args: |
             NEXT_PUBLIC_APP_ENV=development
+            COMMIT_SHA=${{ github.sha }}
       - name: Deploy to Cloud Run
         id: deploy
         uses: google-github-actions/deploy-cloudrun@v2

--- a/.github/workflows/deploy-cloudrun-release.yaml
+++ b/.github/workflows/deploy-cloudrun-release.yaml
@@ -46,6 +46,7 @@ jobs:
           file: ./cloudrun/Dockerfile
           build-args: |
             NEXT_PUBLIC_APP_ENV=production
+            COMMIT_SHA=${{ github.sha }}
 
       - name: Download Cloud Run Service YAML
         run: |

--- a/.github/workflows/deploy-cloudrun-stg.yaml
+++ b/.github/workflows/deploy-cloudrun-stg.yaml
@@ -51,6 +51,7 @@ jobs:
           file: ./cloudrun/Dockerfile
           build-args: |
             NEXT_PUBLIC_APP_ENV=staging
+            COMMIT_SHA=${{ github.sha }}
 
       - name: Download Cloud Run Service YAML
         run: |


### PR DESCRIPTION
## 概要
Cloud Run 向け Docker build に COMMIT_SHA を渡し、フッターのバージョン情報が `dev` にフォールバックし続ける状態を修正します。

## 原因
- `.dockerignore` で `.git` が build context から除外されている
- その状態で Dockerfile の `git rev-parse --short HEAD` フォールバックは使えない
- workflow から `COMMIT_SHA` が渡されていなかったため、`version.json` が `dev` になっていた

## 変更内容
- release/stg/dev/pr 用の Cloud Run workflow で `COMMIT_SHA=${{ github.sha }}` を build-args に追加

## 確認
- ローカルで Dockerfile 相当の分岐を再現し、`.git` が見えない環境では `dev` に落ちることを確認
- 同条件で `COMMIT_SHA` を与えると commit SHA が使われることを確認

Closes #147
