### PR TITLE
管理者向けメンバー管理ダッシュボードを追加

### DIFF
--- a/app/internal/(protected)/admin/members/page.tsx
+++ b/app/internal/(protected)/admin/members/page.tsx
@@ -1,0 +1,40 @@
+import { getAdminMembers } from "@/lib/admin/actions";
+import { MemberDashboardTable } from "@/components/admin/member-dashboard-table";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Users, AlertCircle } from "lucide-react";
+
+export const dynamic = "force-dynamic";
+
+export default async function AdminMembersPage() {
+  let members;
+  let error: string | null = null;
+  try {
+    members = await getAdminMembers();
+  } catch (e) {
+    error = e instanceof Error ? e.message : String(e);
+  }
+
+  return (
+    <div className="container max-w-6xl py-8 px-4">
+      <div className="flex items-center gap-3 mb-6">
+        <Users className="h-6 w-6" />
+        <h1 className="text-2xl font-bold">メンバー管理</h1>
+        {members && (
+          <span className="text-sm text-muted-foreground">
+            全 {members.length} 件
+          </span>
+        )}
+      </div>
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertTitle>メンバー一覧の取得に失敗しました</AlertTitle>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : (
+        <MemberDashboardTable members={members!} />
+      )}
+    </div>
+  );
+}

--- a/app/internal/(protected)/admin/page.tsx
+++ b/app/internal/(protected)/admin/page.tsx
@@ -1,7 +1,9 @@
+import Link from "next/link";
 import { getUnregisteredMembers } from "@/lib/admin/actions";
 import { AdminNotificationPanel } from "@/components/admin/notification-panel";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { Shield, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Shield, AlertCircle, Users } from "lucide-react";
 
 export const dynamic = "force-dynamic";
 
@@ -20,6 +22,16 @@ export default async function AdminPage() {
         <Shield className="h-6 w-6" />
         <h1 className="text-2xl font-bold">管理者ページ</h1>
       </div>
+
+      <section className="mb-8">
+        <h2 className="text-lg font-semibold mb-4">メンバー管理</h2>
+        <Button asChild variant="outline">
+          <Link href="/internal/admin/members">
+            <Users className="h-4 w-4" />
+            メンバー一覧ダッシュボード
+          </Link>
+        </Button>
+      </section>
 
       <section>
         <h2 className="text-lg font-semibold mb-4">登録案内通知</h2>

--- a/components/admin/member-dashboard-table.tsx
+++ b/components/admin/member-dashboard-table.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useState, useMemo } from "react";
+import type { AdminMemberRow } from "@/lib/admin/actions";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuCheckboxItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { SlidersHorizontal } from "lucide-react";
+
+type ColumnDef = {
+  id: string;
+  label: string;
+  defaultVisible: boolean;
+  render: (row: AdminMemberRow) => React.ReactNode;
+};
+
+const COLUMNS: ColumnDef[] = [
+  {
+    id: "name",
+    label: "氏名",
+    defaultVisible: true,
+    render: (r) => (
+      <div>
+        <div className="font-medium">
+          {r.lastName} {r.firstName}
+        </div>
+        {r.nickname && (
+          <div className="text-xs text-muted-foreground">{r.nickname}</div>
+        )}
+      </div>
+    ),
+  },
+  {
+    id: "discord",
+    label: "Discord",
+    defaultVisible: true,
+    render: (r) => (
+      <div>
+        <div className="text-sm">{r.discordUsername}</div>
+        {r.discordHandle && (
+          <div className="text-xs text-muted-foreground">
+            @{r.discordHandle}
+          </div>
+        )}
+      </div>
+    ),
+  },
+  {
+    id: "studentId",
+    label: "学籍番号",
+    defaultVisible: true,
+    render: (r) => (
+      <span className="font-mono text-sm">{r.studentId || "—"}</span>
+    ),
+  },
+  {
+    id: "memberType",
+    label: "種別",
+    defaultVisible: true,
+    render: (r) =>
+      r.memberType ? (
+        <Badge variant="outline">{r.memberType}</Badge>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    id: "year",
+    label: "学年",
+    defaultVisible: true,
+    render: (r) => r.year || <span className="text-muted-foreground">—</span>,
+  },
+  {
+    id: "faculty",
+    label: "学部/学府",
+    defaultVisible: true,
+    render: (r) =>
+      r.faculty || <span className="text-muted-foreground">—</span>,
+  },
+  {
+    id: "interests",
+    label: "興味分野",
+    defaultVisible: false,
+    render: (r) =>
+      r.interests.length > 0 ? (
+        <div className="flex flex-wrap gap-1 max-w-xs">
+          {r.interests.map((tag) => (
+            <Badge key={tag} variant="secondary" className="text-xs">
+              {tag}
+            </Badge>
+          ))}
+        </div>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    id: "github",
+    label: "GitHub",
+    defaultVisible: false,
+    render: (r) =>
+      r.github ? (
+        <a
+          href={`https://github.com/${r.github}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          {r.github}
+        </a>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    id: "x",
+    label: "X",
+    defaultVisible: false,
+    render: (r) =>
+      r.x ? (
+        <a
+          href={`https://x.com/${r.x}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-sm text-blue-600 hover:underline"
+        >
+          @{r.x}
+        </a>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+  {
+    id: "line",
+    label: "LINE",
+    defaultVisible: false,
+    render: (r) =>
+      r.hasLine ? (
+        <span className="text-sm">{r.lineName || "—"}</span>
+      ) : (
+        <span className="text-muted-foreground">未連携</span>
+      ),
+  },
+  {
+    id: "status",
+    label: "ステータス",
+    defaultVisible: true,
+    render: (r) => {
+      if (r.optedOut) return <Badge variant="destructive">退会済</Badge>;
+      if (r.onboardingCompleted)
+        return (
+          <Badge className="bg-blue-100 text-blue-700 border-blue-200">
+            登録済
+          </Badge>
+        );
+      return <Badge variant="outline">未完了</Badge>;
+    },
+  },
+  {
+    id: "createdAt",
+    label: "登録日",
+    defaultVisible: false,
+    render: (r) =>
+      r.createdAt ? (
+        <span className="text-sm text-muted-foreground whitespace-nowrap">
+          {new Date(r.createdAt).toLocaleDateString("ja-JP")}
+        </span>
+      ) : (
+        <span className="text-muted-foreground">—</span>
+      ),
+  },
+];
+
+export function MemberDashboardTable({
+  members,
+}: {
+  members: AdminMemberRow[];
+}) {
+  const [query, setQuery] = useState("");
+  const [visibleColumns, setVisibleColumns] = useState<Set<string>>(
+    () => new Set(COLUMNS.filter((c) => c.defaultVisible).map((c) => c.id)),
+  );
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return members;
+    return members.filter(
+      (m) =>
+        `${m.lastName}${m.firstName}`.includes(q) ||
+        m.nickname.toLowerCase().includes(q) ||
+        m.discordUsername.toLowerCase().includes(q) ||
+        (m.discordHandle ?? "").toLowerCase().includes(q) ||
+        m.studentId.includes(q),
+    );
+  }, [members, query]);
+
+  const visibleCols = COLUMNS.filter((c) => visibleColumns.has(c.id));
+
+  function toggleColumn(id: string) {
+    setVisibleColumns((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <Input
+          placeholder="氏名・Discord・学籍番号で検索"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="max-w-sm"
+        />
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button variant="outline" size="sm" className="gap-1">
+              <SlidersHorizontal className="h-4 w-4" />
+              カラム
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuLabel>表示カラム</DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            {COLUMNS.map((col) => (
+              <DropdownMenuCheckboxItem
+                key={col.id}
+                checked={visibleColumns.has(col.id)}
+                onCheckedChange={() => toggleColumn(col.id)}
+              >
+                {col.label}
+              </DropdownMenuCheckboxItem>
+            ))}
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <span className="text-sm text-muted-foreground">
+          {filtered.length} / {members.length} 件
+        </span>
+      </div>
+
+      <div className="rounded-md border overflow-x-auto">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              {visibleCols.map((col) => (
+                <TableHead key={col.id} className="whitespace-nowrap">
+                  {col.label}
+                </TableHead>
+              ))}
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {filtered.length === 0 ? (
+              <TableRow>
+                <TableCell
+                  colSpan={visibleCols.length}
+                  className="text-center text-muted-foreground py-8"
+                >
+                  該当するメンバーがいません
+                </TableCell>
+              </TableRow>
+            ) : (
+              filtered.map((row) => (
+                <TableRow key={row.discordId}>
+                  {visibleCols.map((col) => (
+                    <TableCell key={col.id} className="align-top py-2">
+                      {col.render(row)}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))
+            )}
+          </TableBody>
+        </Table>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/member-dashboard-table.tsx
+++ b/components/admin/member-dashboard-table.tsx
@@ -149,7 +149,7 @@ const COLUMNS: ColumnDef[] = [
   {
     id: "line",
     label: "LINE",
-    defaultVisible: false,
+    defaultVisible: true,
     render: (r) =>
       r.hasLine ? (
         <span className="text-sm">{r.lineName || "—"}</span>

--- a/lib/admin/actions.ts
+++ b/lib/admin/actions.ts
@@ -9,6 +9,7 @@ import {
   buildOnboardingNudgeMessage,
 } from "@/lib/discord-dm";
 import { getOptoutSubmissionIds } from "@/lib/discord-optout";
+import { getDb } from "@/lib/firebase";
 
 export type MemberStatus = "unregistered" | "onboarding";
 
@@ -126,4 +127,64 @@ export async function sendRegistrationNudge(
   }
 
   return result;
+}
+
+export type AdminMemberRow = {
+  discordId: string;
+  discordUsername: string;
+  discordHandle?: string;
+  lastName: string;
+  firstName: string;
+  nickname: string;
+  studentId: string;
+  memberType?: string;
+  year?: string;
+  faculty?: string;
+  interests: string[];
+  github?: string;
+  x?: string;
+  lineName?: string;
+  hasLine: boolean;
+  onboardingCompleted: boolean;
+  optedOut: boolean;
+  createdAt: string;
+};
+
+export async function getAdminMembers(): Promise<AdminMemberRow[]> {
+  if (!(await isAdmin())) {
+    throw new Error("管理者権限が必要です");
+  }
+
+  const db = getDb();
+  const snap = await db.collection("members").get();
+  const currentYear = String(new Date().getFullYear());
+
+  return snap.docs
+    .map((doc) => {
+      const d = doc.data();
+      const currentEnrollment = (d.enrollments ?? []).find(
+        (e: { isCurrent: boolean }) => e.isCurrent,
+      );
+      return {
+        discordId: doc.id,
+        discordUsername: d.discordUsername ?? "",
+        discordHandle: d.discordHandle,
+        lastName: d.lastName ?? "",
+        firstName: d.firstName ?? "",
+        nickname: d.nickname ?? "",
+        studentId: d.studentId ?? "",
+        memberType: d.memberType,
+        year: d.yearByFiscal?.[currentYear],
+        faculty: currentEnrollment?.faculty,
+        interests: d.interests ?? [],
+        github: d.github,
+        x: d.x,
+        lineName: d.line,
+        hasLine: !!d.lineId,
+        onboardingCompleted: d.onboardingCompleted === true,
+        optedOut: d.optedOut === true,
+        createdAt: d.createdAt?.toDate().toISOString() ?? "",
+      } satisfies AdminMemberRow;
+    })
+    .sort((a, b) => a.lastName.localeCompare(b.lastName, "ja"));
 }


### PR DESCRIPTION
  ## 概要                                                                                     
            
  - Firestore の全メンバーデータを一覧表示する管理者専用ダッシュボードを追加
  - 氏名・Discord・学籍番号・種別・学年・学部/学府・LINE・ステータスをデフォルト表示               
  - 興味分野・GitHub・X・登録日はカラムメニューから表示/非表示を切り替え可能        
  - 氏名・Discord・学籍番号でのインクリメンタル検索に対応                                          
  - LINE は連携済みなら表示名、未連携なら「未連携」と表示                                          
                                                         
  ## 変更ファイル                                                                                  
                                                                                                 
  - `lib/admin/actions.ts` — `getAdminMembers()` と `AdminMemberRow` 型を追加                      
  - `components/admin/member-dashboard-table.tsx` —                                                
  検索・カラム絞込付きテーブルコンポーネント（新規）
  - `app/internal/(protected)/admin/members/page.tsx` — メンバー一覧ページ（新規）                 
  - `app/internal/(protected)/admin/page.tsx` — 管理者トップからダッシュボードへのリンクを追加   
                                                                                                   
  ## テスト
                                                                                                   
  - [ ] 管理者アカウントで `/internal/admin`                                                     
  にアクセスし「メンバー一覧ダッシュボード」ボタンが表示されること                                 
  - [ ] `/internal/admin/members` でメンバー一覧が表示されること  
  - [ ] 検索ボックスで氏名・Discord・学籍番号によるフィルタが動作すること                          
  - [ ] カラムメニューで表示カラムを切り替えられること                                             
  - [ ] LINE 連携済みメンバーは表示名、未連携は「未連携」と表示されること
  - [ ] 非管理者アカウントではアクセスが拒否されること