### PR TITLE
💄 トップページ背景スライドの表示間隔を短縮

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -249,19 +249,19 @@
 }
 
 .bg-slide-1 {
-  animation: backgroundSlide1 48s ease-in-out infinite;
+  animation: backgroundSlide1 24s ease-in-out infinite;
 }
 
 .bg-slide-2 {
-  animation: backgroundSlide2 48s ease-in-out infinite;
+  animation: backgroundSlide2 24s ease-in-out infinite;
 }
 
 .bg-slide-3 {
-  animation: backgroundSlide3 48s ease-in-out infinite;
+  animation: backgroundSlide3 24s ease-in-out infinite;
 }
 
 .bg-slide-4 {
-  animation: backgroundSlide4 48s ease-in-out infinite;
+  animation: backgroundSlide4 24s ease-in-out infinite;
 }
 
 /* 浮遊バブルアニメーション（サンプル顔写真） */


### PR DESCRIPTION
## Summary

- 背景スライドショーのアニメーション時間を 48s → 24s に短縮
- 1枚あたりの表示時間: 約12秒 → 約6秒

## Test plan

- [x] トップページ ( `/` ) を開いて背景画像が約6秒ごとに切り替わることを確認

Close #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)