### PR TITLE
💄 「現在の所属」ラベルを「現在の所属会社・機関（任意）」に明確化

### DIFF
--- a/app/internal/(protected)/profile/page.tsx
+++ b/app/internal/(protected)/profile/page.tsx
@@ -228,7 +228,7 @@ export default async function ProfilePage() {
                 {member.memberType === "卒業生" && (
                   <div>
                     <p className="text-[11px] uppercase tracking-wider text-muted-foreground/70 font-medium">
-                      現在の所属
+                      現在の所属会社・機関
                     </p>
                     <p className="text-sm font-medium mt-0.5">
                       {member.currentOrg || "未設定"}

--- a/components/onboarding/step2-enrollment.tsx
+++ b/components/onboarding/step2-enrollment.tsx
@@ -729,7 +729,12 @@ export function Step2Enrollment({
         {/* 卒業生のみ：現在の所属 */}
         {form.memberType === "卒業生" && (
           <div className="space-y-1.5 animate-[fadeInUp_300ms_ease_both]">
-            <Label htmlFor="currentOrg">現在の所属</Label>
+            <div className="flex items-center gap-1.5">
+              <Label htmlFor="currentOrg">現在の所属会社・機関</Label>
+              <span className="text-[10px] text-muted-foreground border border-muted-foreground/30 px-1.5 py-0.5 rounded">
+                任意
+              </span>
+            </div>
             <Input
               id="currentOrg"
               value={form.currentOrg}

--- a/components/profile-edit.tsx
+++ b/components/profile-edit.tsx
@@ -74,7 +74,7 @@ const FIELD_LABELS: Partial<
   lastNameRomaji: "姓（ローマ字）",
   firstNameRomaji: "名（ローマ字）",
   nickname: "ニックネーム",
-  currentOrg: "現在の所属",
+  currentOrg: "現在の所属会社・機関",
   birthDate: "誕生日",
   gender: "性別",
   bio: "プロフィール文",
@@ -1800,7 +1800,14 @@ export default function ProfileEdit() {
                 >
                   {key !== "bio" && (
                     <div className="flex items-center justify-between">
-                      <Label>{FIELD_LABELS[key]}</Label>
+                      <div className="flex items-center gap-1.5">
+                        <Label>{FIELD_LABELS[key]}</Label>
+                        {key === "currentOrg" && (
+                          <span className="text-[10px] text-muted-foreground border border-muted-foreground/30 px-1.5 py-0.5 rounded">
+                            任意
+                          </span>
+                        )}
+                      </div>
                     </div>
                   )}
 


### PR DESCRIPTION
## Summary

- フォームのラベル「現在の所属」→「現在の所属会社・機関」に変更
- 「任意」バッジをラベル横に追加
- 対象箇所: プロフィール編集フォーム、オンボーディング、プロフィール表示ページ

## Test plan

- [ ] プロフィール編集ページ (`/internal/profile`) でラベルが「現在の所属会社・機関」＋「任意」バッジになっていることを確認（卒業生のみ表示）
- [ ] オンボーディング Step2 で同様に確認
- [ ] `.env.local` に Discord OAuth 情報を設定してローカルでログイン動作を確認

Close #237

🤖 Generated with [Claude Code](https://claude.com/claude-code)