### PR TITLE
🐛 LINE アイコン未設定ユーザーの連携失敗を修正

### DIFF
--- a/app/api/auth/link/line/callback/route.ts
+++ b/app/api/auth/link/line/callback/route.ts
@@ -10,6 +10,8 @@ import {
   checkLineGroupMembership,
   checkLineBotFriendship,
   createLineInvitation,
+  buildLineSnsData,
+  buildLinePendingData,
 } from "@/lib/line-invite";
 
 export async function GET(request: NextRequest) {
@@ -49,18 +51,7 @@ export async function GET(request: NextRequest) {
     const member = await getMember(discordId);
     const isAlumni = member?.memberType === "卒業生";
 
-    /** LINE SNS データ（全フローで共通） */
-    const snsData = {
-      line: user.username,
-      lineId: user.id,
-      lineAvatar: user.avatar,
-      lineLinkedAt: Math.floor(Date.now() / 1000),
-      lineAccessToken: tokenResponse.access_token,
-      lineRefreshToken: tokenResponse.refresh_token,
-      lineTokenExpiresAt: tokenResponse.expires_in
-        ? Math.floor(Date.now() / 1000) + tokenResponse.expires_in
-        : undefined,
-    };
+    const snsData = buildLineSnsData(user, tokenResponse);
 
     /**
      * Bot友だち状態を遅延判定（グループ招待が必要な非卒業生フローでのみ使用）
@@ -105,16 +96,11 @@ export async function GET(request: NextRequest) {
       }
 
       // 未参加 → 仮情報付き招待コード発行（push DMは送らず、Bot友だち追加を促す）
-      await createLineInvitation(discordId, user.id, {
-        pendingLine: user.username,
-        pendingLineId: user.id,
-        pendingLineAvatar: user.avatar,
-        pendingLineAccessToken: tokenResponse.access_token,
-        pendingLineRefreshToken: tokenResponse.refresh_token,
-        pendingLineTokenExpiresAt: tokenResponse.expires_in
-          ? Math.floor(Date.now() / 1000) + tokenResponse.expires_in
-          : undefined,
-      });
+      await createLineInvitation(
+        discordId,
+        user.id,
+        buildLinePendingData(user, tokenResponse),
+      );
 
       const successUrl = new URL(redirectTo, origin);
       successUrl.searchParams.set("success", "line_linked");

--- a/app/api/webhook/line/route.ts
+++ b/app/api/webhook/line/route.ts
@@ -11,6 +11,7 @@ import {
   findMemberByLineId,
   findPendingInvitationByLineId,
   markInvitationUsed,
+  pendingToLineSnsData,
   sendLineReply,
   buildGroupInviteFlexMessage,
   buildGroupJoinedFlexMessage,
@@ -193,15 +194,10 @@ async function handleMemberJoined(event: LineWebhookEvent): Promise<void> {
 
       // 再連携フロー: pending情報がある場合、連携情報を切り替え
       if (invitation.pendingLineId) {
-        await updateMemberSns(invitation.userId, {
-          line: invitation.pendingLine,
-          lineId: invitation.pendingLineId,
-          lineAvatar: invitation.pendingLineAvatar,
-          lineLinkedAt: Math.floor(Date.now() / 1000),
-          lineAccessToken: invitation.pendingLineAccessToken,
-          lineRefreshToken: invitation.pendingLineRefreshToken,
-          lineTokenExpiresAt: invitation.pendingLineTokenExpiresAt,
-        });
+        await updateMemberSns(
+          invitation.userId,
+          pendingToLineSnsData(invitation),
+        );
       }
 
       await markInvitationUsed(code);

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,4 +1,5 @@
 import * as admin from "firebase-admin";
+import { getFirestore } from "firebase-admin/firestore";
 
 // Initialize Firebase lazily
 function initializeFirebase() {
@@ -48,8 +49,7 @@ export function getDb() {
   initializeFirebase();
   const databaseId = process.env.FIRESTORE_DATABASE_ID;
   if (databaseId) {
-    const { getFirestore } = require("firebase-admin/firestore");
-    return getFirestore(databaseId) as admin.firestore.Firestore;
+    return getFirestore(databaseId);
   }
   return admin.firestore();
 }

--- a/lib/line-invite.ts
+++ b/lib/line-invite.ts
@@ -2,6 +2,7 @@ import crypto from "crypto";
 import { getDb } from "@/lib/firebase";
 import { Timestamp } from "firebase-admin/firestore";
 import type { LineFlexMessage, LineFlexBubble } from "@/lib/mini-lt/line-flex";
+import type { OAuthTokenResponse } from "@/lib/oauth-link";
 
 export interface LineInvitation {
   userId: string; // Discord ID
@@ -25,6 +26,82 @@ interface PendingData {
   pendingLineAccessToken: string;
   pendingLineRefreshToken?: string;
   pendingLineTokenExpiresAt?: number;
+}
+
+export interface LineSnsData {
+  line: string;
+  lineId: string;
+  lineLinkedAt: number;
+  lineAccessToken: string;
+  lineAvatar?: string;
+  lineRefreshToken?: string;
+  lineTokenExpiresAt?: number;
+}
+
+/**
+ * LINE 連携時に Firestore へ書き込む SNS データを構築する。
+ * Firestore は undefined フィールドを受け付けないため、未設定のものは含めない
+ * (例: LINE プロフィール画像未設定ユーザー — #252)
+ */
+export function buildLineSnsData(
+  lineUser: { id: string; username: string; avatar?: string },
+  token: OAuthTokenResponse,
+): LineSnsData {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    line: lineUser.username,
+    lineId: lineUser.id,
+    lineLinkedAt: nowSec,
+    lineAccessToken: token.access_token,
+    ...(lineUser.avatar ? { lineAvatar: lineUser.avatar } : {}),
+    ...(token.refresh_token ? { lineRefreshToken: token.refresh_token } : {}),
+    ...(token.expires_in
+      ? { lineTokenExpiresAt: nowSec + token.expires_in }
+      : {}),
+  };
+}
+
+/** 再連携フローで招待コードに仮保存する pending データ。同じく undefined を含めない (#252) */
+export function buildLinePendingData(
+  lineUser: { id: string; username: string; avatar?: string },
+  token: OAuthTokenResponse,
+): PendingData {
+  const nowSec = Math.floor(Date.now() / 1000);
+  return {
+    pendingLine: lineUser.username,
+    pendingLineId: lineUser.id,
+    pendingLineAccessToken: token.access_token,
+    ...(lineUser.avatar ? { pendingLineAvatar: lineUser.avatar } : {}),
+    ...(token.refresh_token
+      ? { pendingLineRefreshToken: token.refresh_token }
+      : {}),
+    ...(token.expires_in
+      ? { pendingLineTokenExpiresAt: nowSec + token.expires_in }
+      : {}),
+  };
+}
+
+/**
+ * 招待コードに仮保存された pending データを SNS データに変換（再連携完了時）。
+ * pendingLine / pendingLineId / pendingLineAccessToken は buildLinePendingData が
+ * 必ず一緒に書き込むため、呼び出し側で `pendingLineId` の存在を確認していれば他も存在する。
+ */
+export function pendingToLineSnsData(invitation: LineInvitation): LineSnsData {
+  return {
+    line: invitation.pendingLine!,
+    lineId: invitation.pendingLineId!,
+    lineLinkedAt: Math.floor(Date.now() / 1000),
+    lineAccessToken: invitation.pendingLineAccessToken!,
+    ...(invitation.pendingLineAvatar
+      ? { lineAvatar: invitation.pendingLineAvatar }
+      : {}),
+    ...(invitation.pendingLineRefreshToken
+      ? { lineRefreshToken: invitation.pendingLineRefreshToken }
+      : {}),
+    ...(invitation.pendingLineTokenExpiresAt
+      ? { lineTokenExpiresAt: invitation.pendingLineTokenExpiresAt }
+      : {}),
+  };
 }
 
 export interface MemberByLineId {


### PR DESCRIPTION
Closes #252

## Summary
- LINE プロフィール画像（`pictureUrl`）未設定のユーザーは `fetchProviderUser("line")` が `avatar: undefined` を返すため、`updateMemberSns` 内の Firestore `update({ lineAvatar: undefined, ... })` が拒否されて連携が失敗していた。
- `lib/line-invite.ts` に LINE 連携用 SNS データ構築ヘルパー (`buildLineSnsData` / `buildLinePendingData` / `pendingToLineSnsData`) を追加し、`undefined` を含まないオブジェクトを返すよう集約。
- 3 箇所（コールバックの初回連携・コールバックの再連携 pending・webhook の memberJoined 再連携完了）でほぼ同じ object literal を書いていたのを一本化。

合わせて軽い掃除:
- `lib/firebase.ts` の `require("firebase-admin/firestore")` を module top の ESM import に置き換え。

検証:
- ローカルで `docker build -f cloudrun/Dockerfile .` を Firebase 認証情報なしで実行し成功を確認（ビルドパスは認証不要、`initializeFirebase()` は `getDb()` 内で lazy なまま）。

## Test plan
- [ ] ローカルで LINE アイコン未設定アカウントで連携 → エラーなく完了
- [ ] LINE アイコン設定済みアカウントで連携 → 引き続き `lineAvatar` が保存される
- [ ] 再連携フロー（LINEグループ未参加 → Bot友だち追加 → グループ参加）が通る
- [ ] 既存の mini-LT などの Firestore 書き込みに影響がない