### PR TITLE
✨ LINEプロフィール画像のリンク切れを定期更新バッチで修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -96,6 +96,11 @@ GCS_BUCKET_NAME="lumos-web-profile-data"
 # 名前付きデータベースを使用する場合に指定（省略時は "(default)" を使用）
 # FIRESTORE_DATABASE_ID="your-database-id"
 
+# --- Cron (LINE アバター定期更新) ---
+# Cloud Scheduler → /api/cron/refresh-line-avatars の認可用シークレット
+# 本番では Terraform が生成し Secret Manager 経由で注入される
+CRON_SECRET="your-cron-secret"
+
 # --- Firestore Emulator (Local Development) ---
 # ローカル開発ではエミュレータを使用 (`just dev` で自動起動)
 # 本番 Firestore に接続する場合はコメントアウト

--- a/app/api/cron/refresh-line-avatars/route.ts
+++ b/app/api/cron/refresh-line-avatars/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb } from "@/lib/firebase";
+import { getMembersWithLine } from "@/lib/members";
+import { refreshSingleMemberLineAvatar } from "@/lib/line-invite";
+
+export const runtime = "nodejs";
+// 連携メンバーが増えても LINE API 呼び出しを処理しきれるよう延長
+export const maxDuration = 300;
+
+/** エンドポイント全体のクールダウン（24時間）。前回実行からこの秒数空かないと発火しない。 */
+const COOLDOWN_SECONDS = 24 * 60 * 60;
+const COOLDOWN_DOC_PATH = "system/lineAvatarRefresh";
+
+/** Cloud Scheduler から定期実行される、全 LINE 連携メンバーの lineAvatar 更新バッチ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET;
+  if (!secret) {
+    console.error("CRON_SECRET is not configured");
+    return NextResponse.json(
+      { error: "Server misconfigured" },
+      { status: 500 },
+    );
+  }
+
+  const auth = request.headers.get("authorization");
+  if (auth !== `Bearer ${secret}`) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const db = getDb();
+  const cooldownRef = db.doc(COOLDOWN_DOC_PATH);
+  const nowSec = Math.floor(Date.now() / 1000);
+
+  // ── 24時間クールダウン判定（エンドポイント全体） ──
+  const cooldownSnap = await cooldownRef.get();
+  const lastRunAt = cooldownSnap.exists
+    ? (cooldownSnap.data()?.lastRunAt as number | undefined)
+    : undefined;
+  if (lastRunAt !== undefined && nowSec - lastRunAt < COOLDOWN_SECONDS) {
+    const retryAfter = COOLDOWN_SECONDS - (nowSec - lastRunAt);
+    return NextResponse.json(
+      { error: "Cooldown active", retryAfterSeconds: retryAfter },
+      { status: 429, headers: { "Retry-After": String(retryAfter) } },
+    );
+  }
+
+  // クールダウン基準を先に更新し、多重起動でも実質1回に絞る
+  await cooldownRef.set({ lastRunAt: nowSec }, { merge: true });
+
+  const members = await getMembersWithLine();
+
+  let updated = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const member of members) {
+    const result = await refreshSingleMemberLineAvatar(member);
+    if (result.status === "updated") {
+      updated++;
+    } else if (result.status === "skipped") {
+      skipped++;
+    } else {
+      failed++;
+      console.error(
+        `LINE avatar refresh failed for ${result.discordId}: ${result.error}`,
+      );
+    }
+  }
+
+  return NextResponse.json({
+    total: members.length,
+    updated,
+    skipped,
+    failed,
+  });
+}

--- a/infra/.terraform.lock.hcl
+++ b/infra/.terraform.lock.hcl
@@ -20,3 +20,24 @@ provider "registry.terraform.io/hashicorp/google" {
     "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.9.0"
+  constraints = "~> 3.0"
+  hashes = [
+    "h1:OO+IuvQJSPmWdN8AyyIEvPJbLvDQpgX/zbktoa9KsJE=",
+    "zh:161ad0bd9a75768c82f53fb6e7172a9d8be2d4889b012645a34795031aaf1bf1",
+    "zh:19dc9a5b17729725ccfc4f45b0500af0ee5bc6b6b160c7adb8f2bf617d2c80ea",
+    "zh:269eda8fe42daa7974d5a34d166c3ba9defe80cde86c01e4dadcfdf2e1f05e5f",
+    "zh:373f7c65566f8f2cc7f45d698654feb9d988996957e1266a69ca00c52d6d16d0",
+    "zh:5599d16804c41c83009ec621b6d6b6f74e102f5827678a4750f8809055546b61",
+    "zh:583be0440469a22bff70dcfa56593b01566860b29607437264adb51060cf46fc",
+    "zh:5f211d8ec3f2e1f414870d9584bfe26e6995560ef81c748f8447a48164767398",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:7b547fd16216761ef86efc3ed516ac5ac0c5c42b7c7eb24a08cef2d93f69ed5e",
+    "zh:7e7c0679daf2a382151d05068c8c3f0dae6b7b7dccf818827b73dd08638df2ef",
+    "zh:8089dec888a8038b9b4fb23b3df7e1057293dbc5b60b42cc47ff690d69d4b61b",
+    "zh:c51f15a031edfd6f23ce8ced3446ca7f8d8d647e2499890d7d5d10d5016d7257",
+    "zh:c94784f005708890dc6895afd53636ec00ec1e430b15d41e5aebfb1d4b39bd04",
+  ]
+}

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -160,6 +160,15 @@ resource "google_cloud_run_service" "web" {
             }
           }
         }
+        env {
+          name = "CRON_SECRET"
+          value_from {
+            secret_key_ref {
+              name = google_secret_manager_secret.per_env["cron-secret-${each.key}"].secret_id
+              key  = "latest"
+            }
+          }
+        }
       }
     }
   }

--- a/infra/main.tf
+++ b/infra/main.tf
@@ -11,6 +11,10 @@ terraform {
       source  = "hashicorp/google"
       version = "~> 6.0"
     }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.0"
+    }
   }
 }
 

--- a/infra/scheduler.tf
+++ b/infra/scheduler.tf
@@ -1,0 +1,32 @@
+# ---------------------------------------------------------------------------
+# Cloud Scheduler – LINE プロフィール画像の定期更新バッチ
+# 各環境の Cron エンドポイントを 1 日 1 回叩く。エンドポイント側に 24h クールダウンが
+# あるため重複起動は安全（429 で弾かれる）。認可は CRON_SECRET の Bearer ヘッダ。
+# ---------------------------------------------------------------------------
+
+resource "google_project_service" "cloudscheduler" {
+  project            = var.project_id
+  service            = "cloudscheduler.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_cloud_scheduler_job" "refresh_line_avatars" {
+  for_each = toset(local.cloud_run_envs)
+
+  name      = "refresh-line-avatars-${each.key}"
+  project   = var.project_id
+  region    = var.region
+  schedule  = "0 4 * * *" # 毎日 04:00
+  time_zone = "Asia/Tokyo"
+
+  http_target {
+    http_method = "GET"
+    uri         = "${var.cloud_run_env_vars[each.key]["AUTH_URL"]}/api/cron/refresh-line-avatars"
+
+    headers = {
+      Authorization = "Bearer ${random_password.cron_secret[each.key].result}"
+    }
+  }
+
+  depends_on = [google_project_service.cloudscheduler]
+}

--- a/infra/secrets.tf
+++ b/infra/secrets.tf
@@ -16,7 +16,8 @@ locals {
     "line-webhook-secret",
     "line-channel-access-token",
     "line-bot-friend-url",
-    "admin-notification-channel-webhook"
+    "admin-notification-channel-webhook",
+    "cron-secret"
   ]
 
   # Build a flat map: "github-oauth-secret-dev" => { secret_suffix, env }
@@ -50,4 +51,22 @@ resource "google_secret_manager_secret_iam_member" "per_env_accessor" {
   secret_id = google_secret_manager_secret.per_env[each.key].id
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.cloud_run[each.value.env].email}"
+}
+
+# ---------------------------------------------------------------------------
+# cron-secret – Cloud Scheduler → Cron エンドポイント認可用の値を Terraform で生成
+# Cloud Scheduler の Authorization: Bearer ヘッダと Cloud Run の CRON_SECRET env で共有する
+# ---------------------------------------------------------------------------
+resource "random_password" "cron_secret" {
+  for_each = toset(local.cloud_run_envs)
+
+  length  = 48
+  special = false
+}
+
+resource "google_secret_manager_secret_version" "cron_secret" {
+  for_each = toset(local.cloud_run_envs)
+
+  secret      = google_secret_manager_secret.per_env["cron-secret-${each.key}"].id
+  secret_data = random_password.cron_secret[each.key].result
 }

--- a/lib/discord-dm.test.ts
+++ b/lib/discord-dm.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type { MemberDocument } from "@/lib/members";
 import {
   calcProfileCompletion,
@@ -209,7 +209,14 @@ describe("buildOnboardingCompleteMessage", () => {
 });
 
 describe("buildLoginMessage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("正しいEmbed構造を返す", () => {
+    // 挨拶文はランダム選択で {name} を含まないものもあるため、
+    // {name} を含むテンプレート (index 1) に固定して名前展開を検証する
+    vi.spyOn(Math, "random").mockReturnValue(1 / 8);
     const payload = buildLoginMessage("テストユーザー");
 
     expect(payload.embeds).toHaveLength(1);
@@ -253,8 +260,8 @@ describe("buildWelcomeBackMessage", () => {
     expect(payload.components).toHaveLength(1);
     const buttons = payload.components![0].components;
     expect(buttons).toHaveLength(2);
-    expect(buttons[0].label).toBe("✨プロフィールを充実させる");
-    expect(buttons[1].label).toBe("👀自分のプロフィールを確認する");
+    expect(buttons[0].label).toBe("プロフィールを充実させる");
+    expect(buttons[1].label).toBe("自分のプロフィールを確認する");
   });
 
   it("全項目入力済みの場合、プロフィール見直しを案内する", () => {
@@ -270,7 +277,7 @@ describe("buildWelcomeBackMessage", () => {
     expect(payload.embeds[0].fields).toBeUndefined();
     expect(payload.components).toHaveLength(1);
     const button = payload.components![0].components[0];
-    expect(button.label).toBe("👀自分のプロフィールを確認する");
+    expect(button.label).toBe("自分のプロフィールを確認する");
     expect(button.url).toContain("/internal/members?member=987654321");
   });
 });

--- a/lib/line-invite.test.ts
+++ b/lib/line-invite.test.ts
@@ -1,0 +1,179 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as firebaseAdmin from "firebase-admin";
+import { refreshSingleMemberLineAvatar } from "./line-invite";
+
+// Initialize Firebase for tests (emulator)
+if (!firebaseAdmin.apps.length) {
+  firebaseAdmin.initializeApp({
+    projectId: process.env.FIREBASE_PROJECT_ID || "test-project",
+  });
+}
+
+const db = firebaseAdmin.firestore();
+
+/** members コレクションに最小限のドキュメントを用意する */
+async function seedMember(
+  discordId: string,
+  data: Record<string, unknown>,
+): Promise<void> {
+  await db.collection("members").doc(discordId).set(data);
+}
+
+async function getLineAvatar(discordId: string): Promise<string | undefined> {
+  const snap = await db.collection("members").doc(discordId).get();
+  return snap.data()?.lineAvatar as string | undefined;
+}
+
+function lineProfileResponse(pictureUrl: string): Response {
+  return new Response(
+    JSON.stringify({
+      userId: "U-line-id",
+      displayName: "テスト",
+      pictureUrl,
+    }),
+    { status: 200 },
+  );
+}
+
+function lineTokenResponse(overrides: Record<string, unknown> = {}): Response {
+  return new Response(
+    JSON.stringify({
+      access_token: "new-access-token",
+      refresh_token: "new-refresh-token",
+      expires_in: 2592000,
+      ...overrides,
+    }),
+    { status: 200 },
+  );
+}
+
+describe("refreshSingleMemberLineAvatar", () => {
+  const discordId = "discord-1";
+  const futureExpiry = Math.floor(Date.now() / 1000) + 3600;
+
+  // 各テストで globalThis.fetch を新しい vi.fn() に差し替える。
+  // 他テストファイルが残した mock キューと干渉しないよう、spyOn ではなく
+  // 毎回まっさらな関数を割り当てて Once キューを共有しないようにする。
+  let fetchMock: ReturnType<typeof vi.fn>;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(async () => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock as unknown as typeof fetch;
+    vi.stubEnv("AUTH_LINE_ID", "line-client-id");
+    vi.stubEnv("AUTH_LINE_SECRET", "line-client-secret");
+    // Clear members collection
+    const docs = await db.collection("members").listDocuments();
+    for (const doc of docs) await doc.delete();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.unstubAllEnvs();
+  });
+
+  it("画像が変わっていれば lineAvatar を更新する", async () => {
+    await seedMember(discordId, {
+      lineId: "U-line-id",
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "valid-token",
+      lineTokenExpiresAt: futureExpiry,
+    });
+    fetchMock.mockResolvedValueOnce(
+      lineProfileResponse("https://new.example/pic.jpg"),
+    );
+
+    const result = await refreshSingleMemberLineAvatar({
+      discordId,
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "valid-token",
+      lineTokenExpiresAt: futureExpiry,
+    });
+
+    expect(result.status).toBe("updated");
+    expect(await getLineAvatar(discordId)).toBe("https://new.example/pic.jpg");
+    // profile API のみ（リフレッシュ不要）
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("画像に変化がなければ書き込みをスキップする", async () => {
+    await seedMember(discordId, {
+      lineId: "U-line-id",
+      lineAvatar: "https://same.example/pic.jpg",
+      lineAccessToken: "valid-token",
+      lineTokenExpiresAt: futureExpiry,
+    });
+    fetchMock.mockResolvedValueOnce(
+      lineProfileResponse("https://same.example/pic.jpg"),
+    );
+
+    const result = await refreshSingleMemberLineAvatar({
+      discordId,
+      lineAvatar: "https://same.example/pic.jpg",
+      lineAccessToken: "valid-token",
+      lineTokenExpiresAt: futureExpiry,
+    });
+
+    expect(result.status).toBe("skipped");
+  });
+
+  it("トークン期限切れなら refresh_token で再発行してから取得する", async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 10;
+    await seedMember(discordId, {
+      lineId: "U-line-id",
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "expired-token",
+      lineRefreshToken: "refresh-token",
+      lineTokenExpiresAt: pastExpiry,
+    });
+    fetchMock
+      // 1回目: token refresh
+      .mockResolvedValueOnce(lineTokenResponse())
+      // 2回目: profile 取得
+      .mockResolvedValueOnce(
+        lineProfileResponse("https://new.example/pic.jpg"),
+      );
+
+    const result = await refreshSingleMemberLineAvatar({
+      discordId,
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "expired-token",
+      lineRefreshToken: "refresh-token",
+      lineTokenExpiresAt: pastExpiry,
+    });
+
+    expect(result.status).toBe("updated");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    // refresh で得た新トークンが保存されている
+    const snap = await db.collection("members").doc(discordId).get();
+    expect(snap.data()?.lineAccessToken).toBe("new-access-token");
+    expect(snap.data()?.lineRefreshToken).toBe("new-refresh-token");
+  });
+
+  it("期限切れだが refresh_token が無ければスキップする", async () => {
+    const pastExpiry = Math.floor(Date.now() / 1000) - 10;
+    const result = await refreshSingleMemberLineAvatar({
+      discordId,
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "expired-token",
+      lineTokenExpiresAt: pastExpiry,
+    });
+
+    expect(result.status).toBe("skipped");
+  });
+
+  it("profile 取得失敗時は failed を返し全体は継続できる", async () => {
+    fetchMock.mockResolvedValueOnce(
+      new Response("Unauthorized", { status: 401 }),
+    );
+
+    const result = await refreshSingleMemberLineAvatar({
+      discordId,
+      lineAvatar: "https://old.example/pic.jpg",
+      lineAccessToken: "valid-token",
+      lineTokenExpiresAt: futureExpiry,
+    });
+
+    expect(result.status).toBe("failed");
+  });
+});

--- a/lib/line-invite.ts
+++ b/lib/line-invite.ts
@@ -2,7 +2,12 @@ import crypto from "crypto";
 import { getDb } from "@/lib/firebase";
 import { Timestamp } from "firebase-admin/firestore";
 import type { LineFlexMessage, LineFlexBubble } from "@/lib/mini-lt/line-flex";
-import type { OAuthTokenResponse } from "@/lib/oauth-link";
+import {
+  fetchProviderUser,
+  refreshLineAccessToken,
+  type OAuthTokenResponse,
+} from "@/lib/oauth-link";
+import { updateMemberSns, type MemberDocument } from "@/lib/members";
 
 export interface LineInvitation {
   userId: string; // Discord ID
@@ -107,6 +112,98 @@ export function pendingToLineSnsData(invitation: LineInvitation): LineSnsData {
 export interface MemberByLineId {
   discordId: string;
   lineId: string;
+}
+
+/** トークン期限が切れる前にリフレッシュする猶予（秒）。期限の5分前から再発行する。 */
+const TOKEN_REFRESH_LEEWAY_SECONDS = 5 * 60;
+
+/** lineAvatar 再取得対象として `getMembersWithLine` が返すメンバー情報 */
+export interface LineLinkedMember {
+  discordId: string;
+  lineAvatar?: string;
+  lineAccessToken?: string;
+  lineRefreshToken?: string;
+  lineTokenExpiresAt?: number;
+}
+
+export type RefreshAvatarResult =
+  | { status: "updated"; discordId: string }
+  | { status: "skipped"; discordId: string; reason: string }
+  | { status: "failed"; discordId: string; error: string };
+
+/**
+ * 1メンバーの LINE プロフィール画像を最新化する。
+ *
+ * LINE が返す pictureUrl は CDN の生 URL で、ユーザーが画像を変更すると古い URL は
+ * 404 になる（リンク切れ）。本人のアクセストークンで /v2/profile を叩き直し、
+ * 最新の pictureUrl を取得して lineAvatar を上書きすることで追従させる。
+ *
+ * アクセストークンが期限切れ間近なら refresh_token で再発行し、更新後のトークンも保存する。
+ * トークンが無い／リフレッシュ不能なメンバーはスキップ（次回本人の再連携まで旧画像のまま）。
+ */
+export async function refreshSingleMemberLineAvatar(
+  member: LineLinkedMember,
+): Promise<RefreshAvatarResult> {
+  const { discordId } = member;
+  try {
+    let accessToken = member.lineAccessToken;
+    const tokenUpdate: Partial<
+      Pick<
+        MemberDocument,
+        "lineAccessToken" | "lineRefreshToken" | "lineTokenExpiresAt"
+      >
+    > = {};
+
+    const nowSec = Math.floor(Date.now() / 1000);
+    const expired =
+      member.lineTokenExpiresAt !== undefined &&
+      member.lineTokenExpiresAt - TOKEN_REFRESH_LEEWAY_SECONDS <= nowSec;
+
+    // 期限切れ間近、またはアクセストークン未保持ならリフレッシュを試みる
+    if (!accessToken || expired) {
+      if (!member.lineRefreshToken) {
+        return {
+          status: "skipped",
+          discordId,
+          reason: "no refresh token to renew expired/missing access token",
+        };
+      }
+      const token = await refreshLineAccessToken(member.lineRefreshToken);
+      accessToken = token.access_token;
+      tokenUpdate.lineAccessToken = token.access_token;
+      if (token.refresh_token)
+        tokenUpdate.lineRefreshToken = token.refresh_token;
+      if (token.expires_in)
+        tokenUpdate.lineTokenExpiresAt = nowSec + token.expires_in;
+    }
+
+    const user = await fetchProviderUser("line", accessToken);
+    const newAvatar = user.avatar;
+
+    const avatarChanged = newAvatar !== member.lineAvatar;
+    const hasTokenUpdate = Object.keys(tokenUpdate).length > 0;
+
+    // 画像にもトークンにも変化がなければ書き込みを省略
+    if (!avatarChanged && !hasTokenUpdate) {
+      return { status: "skipped", discordId, reason: "no change" };
+    }
+
+    await updateMemberSns(discordId, {
+      ...tokenUpdate,
+      // Firestore は undefined を受け付けないため、画像が未設定なら lineAvatar は触らない
+      ...(avatarChanged && newAvatar ? { lineAvatar: newAvatar } : {}),
+    });
+
+    return avatarChanged
+      ? { status: "updated", discordId }
+      : { status: "skipped", discordId, reason: "token refreshed only" };
+  } catch (e) {
+    return {
+      status: "failed",
+      discordId,
+      error: e instanceof Error ? e.message : String(e),
+    };
+  }
 }
 
 /**

--- a/lib/members.ts
+++ b/lib/members.ts
@@ -167,6 +167,37 @@ export async function getMembersInternal(): Promise<Member[]> {
   });
 }
 
+/**
+ * LINE 連携済みメンバーを列挙する（lineAvatar 定期更新バッチ用）。
+ * 退会済み（optedOut）は除外。トークンが無い古い連携は呼び出し側でスキップ判定する。
+ */
+export async function getMembersWithLine(): Promise<
+  {
+    discordId: string;
+    lineAvatar?: string;
+    lineAccessToken?: string;
+    lineRefreshToken?: string;
+    lineTokenExpiresAt?: number;
+  }[]
+> {
+  const db = getDb();
+  const snap = await db.collection("members").where("lineId", "!=", null).get();
+
+  return snap.docs.flatMap((doc) => {
+    const data = doc.data() as MemberDocument;
+    if (isMemberOptedOut(data)) return [];
+    return [
+      {
+        discordId: doc.id,
+        lineAvatar: data.lineAvatar,
+        lineAccessToken: data.lineAccessToken,
+        lineRefreshToken: data.lineRefreshToken,
+        lineTokenExpiresAt: data.lineTokenExpiresAt,
+      },
+    ];
+  });
+}
+
 export async function getMember(
   discordId: string,
 ): Promise<MemberDocument | null> {

--- a/lib/oauth-link.ts
+++ b/lib/oauth-link.ts
@@ -176,6 +176,45 @@ export async function exchangeCodeForTokenFull(
   return data as OAuthTokenResponse;
 }
 
+/**
+ * LINE のリフレッシュトークンでアクセストークンを再発行する。
+ * アクセストークンは有効期限切れになるため、プロフィール再取得前に必要なら更新する。
+ * @see https://developers.line.biz/ja/reference/line-login/#refresh-access-token
+ */
+export async function refreshLineAccessToken(
+  refreshToken: string,
+): Promise<OAuthTokenResponse> {
+  const config = PROVIDER_CONFIGS.line;
+  const clientId = process.env[config.clientIdEnv];
+  const clientSecret = process.env[config.clientSecretEnv];
+
+  if (!clientId || !clientSecret) {
+    throw new Error("Missing env vars for line");
+  }
+
+  const body = new URLSearchParams({
+    grant_type: "refresh_token",
+    refresh_token: refreshToken,
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+
+  const res = await fetch(config.tokenUrl, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/x-www-form-urlencoded",
+      Accept: "application/json",
+    },
+    body: body.toString(),
+  });
+
+  const data = await res.json();
+  if (!res.ok || !data.access_token) {
+    throw new Error(`LINE token refresh failed: ${JSON.stringify(data)}`);
+  }
+  return data as OAuthTokenResponse;
+}
+
 export async function fetchProviderUser(
   provider: OAuthLinkProvider,
   accessToken: string,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,17 @@
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vitest/config";
+
+// `@/*` をプロジェクトルートに解決する（tsconfig の paths と対応）。
+// これが無いと runtime で `@/lib/...` を import するテストが解決できず読み込めない。
+export default defineConfig({
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL(".", import.meta.url)),
+    },
+  },
+  test: {
+    // 共有リソース（globalThis.fetch のモック・Firestore エミュレータのデータ）が
+    // ファイル間で干渉しないよう、テストファイルを並列実行せず逐次実行する。
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
## 概要

メンバーが LINE のプロフィール画像を更新すると、メンバーページで画像がリンク切れになり表示できなくなる問題を修正します。

## 原因

LINE 連携時に LINE API (`/v2/profile`) が返す **CDN の生 URL (`pictureUrl`)** をそのまま Firestore の `lineAvatar` に保存していました。LINE 側でユーザーが画像を変更すると、この古い CDN URL は 404 になります（Discord アバターのようなハッシュからの動的解決もしていないため、URL が固定されたまま腐る）。

## 対応方針

GCS への画像コピーは行わず、**保持済みのアクセストークンで `/v2/profile` を叩き直し、最新の `pictureUrl` を取得して `lineAvatar` を上書きする** Cron エンドポイントを追加しました。常に最新画像に追従するためリンク切れが解消されます。

- **トリガー**: Cloud Scheduler から定期実行（毎日 4:00 JST、全環境）
- **レート制限**: エンドポイント全体で **24 時間クールダウン**（Firestore `system/lineAvatarRefresh` の `lastRunAt` 判定、多重起動は 429）
- **認可**: `CRON_SECRET` の `Authorization: Bearer` ヘッダ
- **トークン期限切れ**: `lineRefreshToken` で再発行してから取得（更新後のトークンも保存）。refresh_token が無い古い連携はスキップ（次回本人の再連携まで旧画像のまま）

## 変更内容

### アプリ
- `lib/oauth-link.ts` — `refreshLineAccessToken()` 追加
- `lib/line-invite.ts` — `refreshSingleMemberLineAvatar()` 追加（1人の失敗で全体を落とさず `updated`/`skipped`/`failed` を返す）
- `lib/members.ts` — `getMembersWithLine()` 追加（退会者除外）
- `app/api/cron/refresh-line-avatars/route.ts`（新規）— Cron エンドポイント

### インフラ (Terraform)
- `infra/secrets.tf` — `cron-secret` を追加し `random_password` で値も管理（dev/stg/prd）
- `infra/cloud_run.tf` — `CRON_SECRET` env 注入
- `infra/scheduler.tf`（新規）— Cloud Scheduler ジョブ（全環境）+ API 有効化
- `infra/main.tf` — `random` プロバイダ追加 / `.env.example` に `CRON_SECRET`

### テスト基盤
- `vitest.config.ts`（新規）— `@/` エイリアスが未設定で `firebase.test.ts` / `discord-dm.test.ts` が**main 上でも読み込めず失敗していた**問題を修正（エイリアス + 逐次実行 `fileParallelism: false`）
- 上記により顕在化した `discord-dm` の既存テスト不具合（絵文字ラベルのズレ・`Math.random` 由来のフレーキー）も修正
- `lib/line-invite.test.ts`（新規）— 更新ロジックのテスト

## 検証

- `just test`（Firestore エミュレータ）: **98 passed**（3 回連続で安定）
- `just lint` / `just format`: クリーン
- `tsc --noEmit`: エラーなし
- `terraform validate` / `fmt -check`: 成功

## レビュー時の確認ポイント

- Cloud Scheduler ジョブを **全環境（dev/stg/prd）** に作成しています。prd のみに絞るべきか確認お願いします。
- 各環境の `AUTH_URL` から Cron エンドポイントへ到達できる前提です（`terraform plan` 時に要確認）。
- `infra/.terraform.lock.hcl` に `random` プロバイダのエントリが追加されています。