### PR TITLE
📝 READMEを外部向けに更新し英語の概要を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,56 @@
 # Lumos Web
 
-横浜国立大学プログラミングサークル「Lumos」の公式サイト。
+横浜国立大学のプログラミングサークル「Lumos」の公式サイトおよびメンバー向けプラットフォームです。
+公開サイト（ニュース・メンバー紹介・お問い合わせ）に加え、Discord 認証によるメンバー限定エリア、週次 Lightning Talk イベント「Mini LT」の管理機能などを備えています。
 
-## 構成
+> Official website and member platform for "Lumos", a programming circle at Yokohama National University, Japan.
+>
+> At its core, this is a platform for the circle's members and organizers. Members maintain rich profiles — name/nickname, department, academic year, membership type (undergraduate / graduate / alumni), interests, bio, avatar images, and linked social accounts (GitHub, X, LINE, Discord) — and share them within the circle, with per-field visibility controls and avatar selection. For the operations side, it provides admin tooling for detailed member management: a member dashboard, role assignment based on Discord guild roles, notifications, and an onboarding flow for newly joined members.
+>
+> Authentication is built on Discord OAuth (NextAuth.js v5), matching how the circle actually communicates day to day. The site also serves the public pages (news, member directory, contact) and a management system for "Mini LT", the circle's weekly lightning-talk event — including automated Discord event creation via a bot and LINE push notifications (Flex Messages).
 
-| パス                  | 説明                                             |
-| --------------------- | ------------------------------------------------ |
-| `app/`                | Next.js App Router ページ                        |
-| `app/mini-lt/`        | Mini LT プロジェクト（週次LTイベント管理）       |
-| `app/internal/`       | サークルメンバー向け内部ページ（要認証）         |
-| `components/`         | 共通UIコンポーネント                             |
-| `components/mini-lt/` | Mini LT 専用コンポーネント                       |
-| `lib/`                | サーバーサイドユーティリティ                     |
-| `lib/mini-lt/`        | Mini LT 専用ロジック（Firebase, utils, actions） |
-| `types/`              | 型定義                                           |
+## 機能 / Features
 
-## 技術スタック
+- **公開サイト**: ランディングページ、ニュース、メンバー一覧、お問い合わせ
+  - Public pages: landing, news, member directory, contact
+- **メンバーエリア (`/internal`)**: Discord OAuth ログイン必須。プロフィール編集・画像アップロード、メンバー設定、GitHub / X / LINE アカウント連携、新規メンバーのオンボーディングフロー
+  - Members-only area (`/internal`): Discord OAuth login, profile editing with image upload (GCS), account linking with GitHub / X / LINE, onboarding flow for new members
+- **Mini LT 管理**: 週次 LT イベントの作成・管理、管理者パネル、Discord イベントの自動作成（Bot 経由）、LINE プッシュ通知（Flex Message）
+  - Mini LT management: weekly lightning-talk event scheduling, admin panel, automated Discord event creation via bot, LINE push notifications (Flex Messages)
+- **権限管理**: Discord ギルドのロールに基づく管理者判定
+  - Role-based admin detection via Discord guild roles
 
-- **フレームワーク**: Next.js 16 (App Router)
-- **認証**: NextAuth.js v5 (Discord OAuth)
-- **データベース**: Firestore (Firebase Admin SDK)
-- **スタイル**: Tailwind CSS + shadcn/ui
+## 技術スタック / Tech Stack
+
+- **フレームワーク**: Next.js 16 (App Router) + React 19 + TypeScript
+- **認証**: NextAuth.js v5（Discord OAuth、セカンダリ OAuth 連携: GitHub / X / LINE）
+- **データベース**: Cloud Firestore（Firebase Admin SDK、ローカル開発は Firestore Emulator）
+- **スタイル**: Tailwind CSS + shadcn/ui (Radix UI)
+- **フォーム**: react-hook-form + zod
 - **テスト**: Vitest + Firestore Emulator
+- **外部連携**: Discord API（OAuth / ギルド検証 / Bot）、LINE Messaging API、Google Cloud Storage
+
+## インフラ・CI/CD / Infrastructure
+
+- **デプロイ**: Google Cloud Run（`output: "standalone"` ビルドを Docker イメージ化）
+- **IaC**: Terraform（`infra/` — Cloud Run, Firestore, GCS, Cloud Scheduler, Service Account 等）
+- **CI/CD**: GitHub Actions — dev / stg / release 環境へのデプロイ、PR ごとのプレビュー環境構築とクローズ時の自動削除、Lint チェック
+- **定期実行**: Cloud Scheduler + `/api/cron` によるスケジュール処理
+
+## ディレクトリ構成
+
+| パス                  | 説明                                              |
+| --------------------- | ------------------------------------------------- |
+| `app/`                | Next.js App Router ページ                         |
+| `app/mini-lt/`        | Mini LT プロジェクト（週次LTイベント管理）        |
+| `app/internal/`       | サークルメンバー向け内部ページ（要認証）          |
+| `app/api/`            | API ルート（プロフィール、連携、Webhook、cron等） |
+| `components/`         | 共通UIコンポーネント                              |
+| `components/mini-lt/` | Mini LT 専用コンポーネント                        |
+| `lib/`                | サーバーサイドユーティリティ                      |
+| `lib/mini-lt/`        | Mini LT 専用ロジック（Firebase, utils, actions）  |
+| `infra/`              | Terraform によるインフラ定義                      |
+| `types/`              | 型定義                                            |
 
 ## セットアップ
 


### PR DESCRIPTION
## 概要

外部の人がリポジトリを見たときにプロジェクトの全体像が伝わるよう、README を更新しました。

## 変更点

- 冒頭に概要を追加（日本語＋英語併記）
  - 英語の概要では、メンバーが詳細なプロフィール（学部・学年・メンバー種別・興味分野・SNS連携等）を共有する場であること、運営側のメンバー管理（ダッシュボード・ロール割り当て・オンボーディング）を備えていることを詳細に記述
- 機能一覧セクション（Features）を日英併記で新設
- 技術スタックを拡充（NextAuth v5、react-hook-form + zod、外部連携など）
- インフラ・CI/CD セクションを新設（Cloud Run、Terraform、GitHub Actions、Cloud Scheduler）
- ディレクトリ構成に `app/api/` と `infra/` を追加

開発者向けの既存情報（セットアップ、just コマンド、Firestore エミュレータ、環境変数、認証）は変更なし。